### PR TITLE
Make the pane resizable on mobile

### DIFF
--- a/src/assets/tailwind.css
+++ b/src/assets/tailwind.css
@@ -25,17 +25,8 @@ div[contenteditable='true']:focus {
   --top: minmax(0, 1fr);
   --bottom: minmax(0, 1fr);
 
-  grid-template-rows: auto minmax(0, var(--top)) 20px auto minmax(0, var(--bottom));
+  grid-template-rows: auto minmax(0, var(--top)) 12px auto minmax(0, var(--bottom));
   grid-template-columns: 1fr;
-}
-
-.grid-resizer {
-  @apply relative z-50;
-}
-
-.grid-resizer:hover::after {
-  content: '';
-  @apply absolute bg-brand-default top-[-6px] bottom-[-6px] w-full;
 }
 
 @screen md {
@@ -44,11 +35,7 @@ div[contenteditable='true']:focus {
     --right: minmax(0, 1fr);
 
     grid-template-rows: auto minmax(0, 1fr);
-    grid-template-columns: minmax(0, var(--left)) 2px minmax(0, var(--right));
-  }
-
-  .grid-resizer:hover::after {
-    @apply top-0 left-[-6px] right-[-6px] h-full w-auto bottom-0;
+    grid-template-columns: minmax(0, var(--left)) 12px minmax(0, var(--right));
   }
 }
 

--- a/src/assets/tailwind.css
+++ b/src/assets/tailwind.css
@@ -22,17 +22,20 @@ div[contenteditable='true']:focus {
 
 .wrapper,
 .wrapper--forced {
-  grid-template-rows: auto minmax(0, 1fr) auto minmax(0, 1fr);
+  --top: minmax(0, 1fr);
+  --bottom: minmax(0, 1fr);
+
+  grid-template-rows: auto minmax(0, var(--top)) 20px auto minmax(0, var(--bottom));
   grid-template-columns: 1fr;
 }
 
-.column-resizer {
+.grid-resizer {
   @apply relative z-50;
 }
 
-.column-resizer:hover::after {
+.grid-resizer:hover::after {
   content: '';
-  @apply absolute top-0 left-[-6px] right-[-6px] bg-brand-default h-full;
+  @apply absolute bg-brand-default top-[-6px] bottom-[-6px] w-full;
 }
 
 @screen md {
@@ -42,6 +45,10 @@ div[contenteditable='true']:focus {
 
     grid-template-rows: auto minmax(0, 1fr);
     grid-template-columns: minmax(0, var(--left)) 2px minmax(0, var(--right));
+  }
+
+  .grid-resizer:hover::after {
+    @apply top-0 left-[-6px] right-[-6px] h-full w-auto bottom-0;
   }
 }
 

--- a/src/components/gridResizer/dot.tsx
+++ b/src/components/gridResizer/dot.tsx
@@ -1,0 +1,5 @@
+import type { Component, JSX } from 'solid-js';
+
+export const Dot: Component = () => {
+  return <span class="m-1 w-1 h-1 rounded-full bg-blueGray-200" />;
+};

--- a/src/components/gridResizer/gridResizer.tsx
+++ b/src/components/gridResizer/gridResizer.tsx
@@ -4,7 +4,6 @@ import {
   splitProps,
   createSignal,
   createEffect,
-  onMount,
   onCleanup,
 } from 'solid-js';
 import { throttle } from '../../utils/throttle';
@@ -14,8 +13,6 @@ interface GridResizerProps extends JSX.HTMLAttributes<HTMLDivElement> {
   ref?: (el: HTMLDivElement) => any | undefined;
   isHorizontal: boolean;
   direction: 'horizontal' | 'vertical';
-  onResizeStart?: () => void;
-  onResizeEnd?: () => void;
   onResize: (clientX: number, clientY: number) => void;
 }
 
@@ -26,24 +23,16 @@ export const GridResizer: Component<GridResizerProps> = (props) => {
     'isHorizontal',
     'direction',
     'onResize',
-    'onResizeStart',
-    'onResizeEnd',
   ]);
 
   const [isDragging, setIsDragging] = createSignal(false);
 
   const onResizeStart = () => {
     setIsDragging(true);
-    if (local.onResizeStart) {
-      local.onResizeStart();
-    }
   };
 
   const onResizeEnd = () => {
     setIsDragging(false);
-    if (local.onResizeEnd) {
-      local.onResizeEnd();
-    }
   };
 
   const onMouseMove = throttle((e: MouseEvent) => {

--- a/src/components/gridResizer/gridResizer.tsx
+++ b/src/components/gridResizer/gridResizer.tsx
@@ -1,0 +1,115 @@
+import {
+  Component,
+  JSX,
+  splitProps,
+  createSignal,
+  createEffect,
+  onMount,
+  onCleanup,
+} from 'solid-js';
+import { throttle } from '../../utils/throttle';
+import { Dot } from './dot';
+
+interface GridResizerProps extends JSX.HTMLAttributes<HTMLDivElement> {
+  ref?: (el: HTMLDivElement) => any | undefined;
+  isHorizontal: boolean;
+  direction: 'horizontal' | 'vertical';
+  onResizeStart?: () => void;
+  onResizeEnd?: () => void;
+  onResize: (clientX: number, clientY: number) => void;
+}
+
+export const GridResizer: Component<GridResizerProps> = (props) => {
+  const [local, other] = splitProps(props, [
+    'ref',
+    'class',
+    'isHorizontal',
+    'direction',
+    'onResize',
+    'onResizeStart',
+    'onResizeEnd',
+  ]);
+
+  const [isDragging, setIsDragging] = createSignal(false);
+
+  const onResizeStart = () => {
+    setIsDragging(true);
+    if (local.onResizeStart) {
+      local.onResizeStart();
+    }
+  };
+
+  const onResizeEnd = () => {
+    setIsDragging(false);
+    if (local.onResizeEnd) {
+      local.onResizeEnd();
+    }
+  };
+
+  const onMouseMove = throttle((e: MouseEvent) => {
+    local.onResize(e.clientX, e.clientY);
+  }, 10);
+
+  const onTouchMove = throttle((e: TouchEvent) => {
+    const touch = e.touches[0];
+    local.onResize(touch.clientX, touch.clientY);
+  }, 10);
+
+  const setRef = (el: HTMLDivElement) => {
+    if (local.ref) {
+      local.ref(el);
+    }
+
+    el.addEventListener('mousedown', onResizeStart);
+    el.addEventListener('touchstart', onResizeStart);
+
+    onCleanup(() => {
+      el.removeEventListener('mousedown', onResizeStart);
+      el.removeEventListener('touchstart', onResizeStart);
+    });
+  };
+
+  createEffect(() => {
+    if (isDragging()) {
+      window.addEventListener('mousemove', onMouseMove);
+      window.addEventListener('mouseup', onResizeEnd);
+      window.addEventListener('touchmove', onTouchMove);
+      window.addEventListener('touchend', onResizeEnd);
+    } else {
+      window.removeEventListener('mousemove', onMouseMove);
+      window.removeEventListener('mouseup', onResizeEnd);
+      window.removeEventListener('touchmove', onTouchMove);
+      window.removeEventListener('touchend', onResizeEnd);
+    }
+  });
+
+  const baseClasses = 'justify-center items-center border-blueGray-200 hover:bg-brand-default';
+  const resizingClasses = () =>
+    `${isDragging() ? 'bg-brand-default' : 'bg-blueGray-50 dark:bg-blueGray-800'}`;
+  const directionClasses = () =>
+    local.direction === 'horizontal'
+      ? `flex-col cursor-col-resize border-l-2 border-r-2 hidden${
+          !local.isHorizontal ? ' md:flex' : ' '
+        }`
+      : `cursor-row-resize border-t-2 border-b-2 flex${!local.isHorizontal ? ' md:hidden' : ' '}`;
+  const classes = () => `${baseClasses} ${resizingClasses()} ${directionClasses()} ${local.class}`;
+
+  return (
+    <>
+      <div
+        class={
+          isDragging()
+            ? `fixed inset-0 z-50 ${
+                local.direction === 'horizontal' ? 'cursor-col-resize' : 'cursor-row-resize'
+              }`
+            : 'hidden'
+        }
+      />
+      <div ref={setRef} class={classes()} {...other}>
+        <Dot />
+        <Dot />
+        <Dot />
+      </div>
+    </>
+  );
+};

--- a/src/components/gridResizer/index.tsx
+++ b/src/components/gridResizer/index.tsx
@@ -1,0 +1,1 @@
+export * from './gridResizer';

--- a/src/components/repl.tsx
+++ b/src/components/repl.tsx
@@ -205,6 +205,16 @@ export const Repl: Component<ReplProps> = (props) => {
    * Upcomming 2 blocks before the slice of view is used for horizontal and vertical resizers.
    * This first block controls the horizontal resizer.
    */
+  const adjustPercentage = (percentage: number, lowerBound: number, upperBound: number) => {
+    if (percentage < lowerBound) {
+      return lowerBound;
+    } else if (percentage > upperBound) {
+      return upperBound;
+    } else {
+      return percentage;
+    }
+  };
+
   const [horizontalResizer, setHorizontalResizer] = createSignal<HTMLElement>();
   const [left, setLeft] = createSignal(1.25);
 
@@ -212,10 +222,11 @@ export const Repl: Component<ReplProps> = (props) => {
     // Adjust the reading according to the width of the resizable panes
     const clientXAdjusted = clientX - horizontalResizer()!.offsetWidth / 2;
     const widthAdjusted = document.body.offsetWidth - horizontalResizer()!.offsetWidth;
-    const percentage = clientXAdjusted / (widthAdjusted / 2);
-    if (percentage < 0.5 || percentage > 1.5) return;
 
-    setLeft(percentage);
+    const percentage = clientXAdjusted / (widthAdjusted / 2);
+    const percentageAdjusted = adjustPercentage(percentage, 0.5, 1.5);
+
+    setLeft(percentageAdjusted);
   };
 
   /**
@@ -240,9 +251,9 @@ export const Repl: Component<ReplProps> = (props) => {
       resultTabs()!.offsetHeight;
 
     const percentage = clientYAdjusted / (heightAdjusted / 2);
-    if (percentage < 0.5 || percentage > 1.5) return;
+    const percentageAdjusted = adjustPercentage(percentage, 0.5, 1.5);
 
-    setTop(percentage);
+    setTop(percentageAdjusted);
   };
 
   return (

--- a/src/components/repl.tsx
+++ b/src/components/repl.tsx
@@ -207,7 +207,6 @@ export const Repl: Component<ReplProps> = (props) => {
    */
   const [horizontalResizer, setHorizontalResizer] = createSignal<HTMLElement>();
   const [left, setLeft] = createSignal(1.25);
-  const [isDraggingHorizontal, setIsDraggingHorizontal] = createSignal(false);
 
   const changeLeft = (clientX: number, _clientY: number) => {
     // Adjust the reading according to the width of the resizable panes
@@ -227,7 +226,6 @@ export const Repl: Component<ReplProps> = (props) => {
   const [resultTabs, setResultTabs] = createSignal<HTMLElement>();
   const [verticalResizer, setVerticalResizer] = createSignal<HTMLElement>();
   const [top, setTop] = createSignal(1);
-  const [isDraggingVertical, setIsDraggingVertical] = createSignal(false);
 
   const changeTop = (_clientX: number, clientY: number) => {
     // Adjust the reading according to the height of the resizable panes
@@ -421,8 +419,6 @@ export const Repl: Component<ReplProps> = (props) => {
           isHorizontal={props.isHorizontal}
           direction="vertical"
           class="row-start-3"
-          onResizeStart={() => setIsDraggingVertical(true)}
-          onResizeEnd={() => setIsDraggingVertical(false)}
           onResize={changeTop}
         />
 
@@ -431,8 +427,6 @@ export const Repl: Component<ReplProps> = (props) => {
           isHorizontal={props.isHorizontal}
           direction="horizontal"
           class="row-start-1 row-end-3 col-start-2"
-          onResizeStart={() => setIsDraggingHorizontal(true)}
-          onResizeEnd={() => setIsDraggingHorizontal(false)}
           onResize={changeLeft}
         />
 
@@ -506,9 +500,6 @@ export const Repl: Component<ReplProps> = (props) => {
             class={`h-full w-full bg-white row-start-5 ${
               props.isHorizontal ? '' : 'md:row-start-2'
             }`}
-            classList={{
-              'pointer-events-none': isDraggingHorizontal() || isDraggingVertical(),
-            }}
           />
         </Show>
       </Suspense>

--- a/src/components/repl.tsx
+++ b/src/components/repl.tsx
@@ -444,7 +444,7 @@ export const Repl: Component<ReplProps> = (props) => {
 
         <div
           ref={(el) => setResizer(el)}
-          class={'grid-resizer h-full w-full row-start-3 cursor-row-resize md:hidden'}
+          class={'grid-resizer row-start-3 cursor-row-resize md:hidden'}
           onMouseDown={[setIsDraggingRow, true]} onTouchStart={[setIsDraggingRow, true]}
         >
           <div class="border-blueGray-200 dark:border-blueGray-700 border-t border-b rounded-lg w-full my-auto h-0"></div>

--- a/src/components/tab/list.tsx
+++ b/src/components/tab/list.tsx
@@ -3,6 +3,7 @@ import type { Component, JSX } from 'solid-js';
 export const TabList: Component<JSX.HTMLAttributes<HTMLUListElement>> = (props) => {
   return (
     <ul
+      ref={props.ref}
       class={`flex tabs flex-wrap items-center list-none bg-white dark:bg-blueGray-800 m-0 ${
         props.class || ''
       }`}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -27,6 +27,10 @@ module.exports = {
       fontSize: {
         '0.5sm': ['0.84375rem', '1.25rem'],
       },
+      cursor: {
+        'col-resize': 'col-resize',
+        'row-resize': 'row-resize'
+      }
     },
   },
   darkMode: 'class',


### PR DESCRIPTION
Hello. Since I saw #9 was open, I thought I would give it a go and try to solve it. This is an initial implementation, I would like to get some points clarified before finishing it. I tried using a similar approach as the one used for horizontal resizing.
First of all, I made the div responsible for resizing 20px tall. It is not very pretty but it correctly registers touch movements unlike its smaller counterpart. I was thinking of making it as small as the one for horizontal resizing and making an invisible touch area around it, but I am not sure if it would collide with the Result and Output buttons. I can check it out if you would like to go this path.
On the same topic, I was thinking of putting a three grey dots (or something similar) inside the div as an indicator of the possibility to resize the panes, since hovering on the phone is triggered on click and it might not be as obvious as on the desktop.
I was also thinking about the indicator which is displayed on hover. I was thinking of enabling the effect not only on hover, but also during the process of resizing. If you move the mouse too quickly and the cursor is not hovering over the div, the effect is lost. It is even worse on phone.
For "normalizing" the measurements of mouse/touch events I used a couple of refs to get the heights of the surrounding non-resizeable elements. It was possible to hardcode the measurements from CSS, but I thought this was a better approach in case the layout changes in the future. Also the calculations could be put in a memo instead of recalculating them on every onMouse/onTouch movement, but I do not think there would be a significant performance gain.
These are the points I would like clarification on. I am open for discussion and other implementation changes or suggestions.