### PR TITLE
Scaling feature

### DIFF
--- a/playground/app.tsx
+++ b/playground/app.tsx
@@ -23,6 +23,7 @@ import { isValidUrl } from './utils/isValidUrl';
 
 import CompilerWorker from '../src/workers/compiler?worker';
 import FormatterWorker from '../src/workers/formatter?worker';
+import useZoom from '../src/hooks/useZoom';
 
 (window as any).MonacoEnvironment = {
   getWorker(_moduleId: unknown, label: string) {
@@ -107,6 +108,26 @@ export const App = (): JSX.Element => {
   const interactive = !noInteractive;
   const actionBar = !noActionBar;
   const editableTabs = !noEditableTabs;
+
+  const { zoomState, updateZoomScale } = useZoom();
+
+  document.addEventListener('keydown', (e) => {
+    const key = e.key;
+
+    if (!zoomState.overrideNative) return;
+
+    if (!((e.ctrlKey || e.metaKey) && (key === '=' || key === '-'))) {
+      return;
+    }
+
+    e.preventDefault();
+
+    if (key === '=') {
+      updateZoomScale('increase');
+    } else {
+      updateZoomScale('decrease');
+    }
+  });
 
   return (
     <div class="relative flex bg-blueGray-50 h-screen overflow-hidden text-blueGray-900 dark:text-blueGray-50 font-sans flex-col">

--- a/playground/components/header.tsx
+++ b/playground/components/header.tsx
@@ -14,6 +14,7 @@ import logo from '../assets/logo.svg?url';
 import { processImport, Tab } from '../../src';
 import { exportToCsb } from '../utils/exportToCsb';
 import { exportToJSON } from '../utils/exportToJson';
+import { ZoomDropdown } from './zoomDropdown';
 
 export const Header: Component<{
   dark: boolean;
@@ -71,7 +72,7 @@ export const Header: Component<{
 
   return (
     <header
-      class="p-2 flex text-sm justify-between items-center bg-brand-default text-white"
+      class="p-2 flex text-sm justify-between items-center bg-brand-default text-white z-20"
       classList={{ 'md:col-span-3': !props.isHorizontal }}
     >
       <h1 class="flex items-center space-x-4 uppercase leading-0 tracking-widest">
@@ -172,6 +173,7 @@ export const Header: Component<{
               <Icon class="h-6" path={copy() ? link : share} />
               <span class="text-xs md:sr-only">{copy() ? 'Copied to clipboard' : 'Share'}</span>
             </button>
+            <ZoomDropdown showMenu={showMenu()} />
           </div>
         </div>
         <button

--- a/playground/components/zoomDropdown.tsx
+++ b/playground/components/zoomDropdown.tsx
@@ -1,97 +1,162 @@
 import { Icon } from '@amoutonbrady/solid-heroicons';
 import { zoomIn } from '@amoutonbrady/solid-heroicons/outline';
-import { Component, createSignal, Show } from 'solid-js';
+import { Component, createSignal, Show, createEffect } from 'solid-js';
 import useFocusOut from '../../src/hooks/useFocusOut';
 import useZoom from '../../src/hooks/useZoom';
 
 export const ZoomDropdown: Component<{ showMenu: boolean }> = (props) => {
-  const [_, { onFOBlur, onFOClick, onFOFocus }] = useFocusOut({ onToggle });
-  const [open, setOpen] = createSignal(false);
+  const [[toggle, setToggle], { onFOBlur, onFOClick, onFOFocus }] = useFocusOut();
+  const { zoomState, updateZoomScale, updateZoomSettings } = useZoom();
+  const popupDuration = 1250;
+  let containerEl!: HTMLDivElement;
+  let prevZoom = zoomState.zoom;
+  let timeoutId: number | null = null;
+  let btnEl!: HTMLButtonElement;
+  let prevFocusedEl: HTMLElement | null;
+  let stealFocus = true;
 
-  function onToggle(toggle: boolean) {
-    setOpen(toggle);
-  }
+  const onMouseMove = () => {
+    stealFocus = true;
+    window.clearTimeout(timeoutId!);
+  };
+
+  const onKeyDownContainer = (e: KeyboardEvent) => {
+    if (!toggle()) return;
+
+    if (e.key === 'Escape' && !stealFocus) {
+      if (prevFocusedEl) {
+        prevFocusedEl.focus();
+        stealFocus = true;
+      }
+      window.clearTimeout(timeoutId!);
+    }
+
+    if (!['Tab', 'Enter', 'Space'].includes(e.key)) return;
+    stealFocus = false;
+    prevFocusedEl = null;
+    window.clearTimeout(timeoutId!);
+  };
+
+  createEffect(() => {
+    if (prevZoom === zoomState.zoom) return;
+    prevZoom = zoomState.zoom;
+
+    if (stealFocus) {
+      prevFocusedEl = document.activeElement as HTMLElement;
+      btnEl.focus();
+      stealFocus = false;
+    }
+
+    setToggle(true);
+
+    window.clearTimeout(timeoutId!);
+
+    timeoutId = setTimeout(() => {
+      setToggle(false);
+
+      stealFocus = true;
+      if (prevFocusedEl) {
+        prevFocusedEl.focus();
+      }
+    }, popupDuration);
+  });
+
+  createEffect(() => {
+    if (!toggle()) {
+      if (containerEl) {
+        containerEl.removeEventListener('mousemove', onMouseMove);
+      }
+      stealFocus = true;
+    } else {
+      if (containerEl) {
+        containerEl.addEventListener('mousemove', onMouseMove, { once: true });
+      }
+    }
+  });
 
   return (
-    <div class="relative" onFocusIn={onFOFocus} onFocusOut={onFOBlur} tabindex="-1">
+    <div
+      class="relative"
+      onFocusIn={onFOFocus}
+      onFocusOut={onFOBlur}
+      onKeyDown={onKeyDownContainer}
+      onClick={() => {
+        window.clearTimeout(timeoutId!);
+      }}
+      ref={containerEl}
+      tabindex="-1"
+    >
       <button
         type="button"
         class="text-black md:text-white flex flex-row space-x-2 items-center w-full md:px-3 px-2 py-2 focus:ring-1 rounded text-white opacity-80 hover:opacity-100"
         classList={{
-          'bg-gray-900': open() && !props.showMenu,
-          'bg-gray-300': open() && props.showMenu,
+          'bg-gray-900': toggle() && !props.showMenu,
+          'bg-gray-300': toggle() && props.showMenu,
           'rounded-none	active:bg-gray-300 hover:bg-gray-300 focus:outline-none focus:highlight-none active:highlight-none focus:ring-0 active:outline-none':
             props.showMenu,
         }}
         onClick={onFOClick}
         title="Scale editor to make text larger or smaller"
+        ref={btnEl}
       >
         <Icon class="h-6" path={zoomIn} />
         <span class="text-xs md:sr-only">Scale Editor</span>
       </button>
-      <Show when={open()}>
+      <Show when={toggle()}>
         <div
           class="absolute top-full left-1/2 bg-white text-brand-default border border-gray-900 rounded shadow  p-6 -translate-x-1/2 z-10"
           classList={{
             'left-1/4': props.showMenu,
           }}
         >
-          <ScaleButtons></ScaleButtons>
+          <div class="flex">
+            <button
+              class="bg-gray-500 text-white px-3 py-1 rounded-l text-sm uppercase tracking-wide hover:bg-gray-800"
+              aria-label="decrease font size"
+              onClick={() => updateZoomScale('decrease')}
+            >
+              -
+            </button>
+            <div class="text-black bg-gray-100 px-3 py-1 text-sm text-center w-20 uppercase tracking-wide ">
+              {zoomState.zoom}%
+            </div>
+            <button
+              class="bg-gray-500 text-white px-3 py-1 rounded-r text-sm uppercase tracking-wide mr-4 hover:bg-gray-800"
+              aria-label="increase font size"
+              onClick={() => updateZoomScale('increase')}
+            >
+              +
+            </button>
+            <button
+              class="bg-gray-500 text-white px-3 py-1 rounded  text-sm uppercase tracking-wide hover:bg-gray-800"
+              aria-label="reset font size"
+              onClick={() => updateZoomScale('reset')}
+            >
+              Reset
+            </button>
+          </div>
           <div className="mt-10">
             <label class="block my-3 cursor-pointer">
-              <input type="checkbox" class="mr-4 cursor-pointer" checked={true} />
+              <input
+                type="checkbox"
+                class="mr-4 cursor-pointer"
+                checked={zoomState.overrideNative}
+                onChange={(e) => updateZoomSettings('overrideNative', e.currentTarget.checked)}
+              />
               Override native zoom keyboard shortcut
             </label>
             <label class="block my-3 cursor-pointer">
-              <input type="checkbox" class="mr-4 cursor-pointer" checked={true} />
+              <input
+                type="checkbox"
+                class="mr-4 cursor-pointer"
+                checked={zoomState.scaleIframe}
+                onChange={(e) => updateZoomSettings('scaleIframe', e.currentTarget.checked)}
+              />
               Scale iframe <strong>Result</strong>
             </label>
           </div>
         </div>
       </Show>
-    </div>
-  );
-};
-
-const ScaleButtons = () => {
-  const { zoomState, updateZoom } = useZoom();
-
-  return (
-    <div class="flex">
-      <button
-        class="bg-gray-500 text-white px-3 py-1 rounded-l text-sm uppercase tracking-wide hover:bg-gray-800"
-        aria-label="decrease font size"
-        onClick={() => updateZoom('decrease')}
-      >
-        -
-      </button>
-      <div class="text-black bg-gray-100 px-3 py-1 text-sm text-center w-20 uppercase tracking-wide ">
-        {zoomState.zoom}%
-      </div>
-      <button
-        class="bg-gray-500 text-white px-3 py-1 rounded-r text-sm uppercase tracking-wide mr-4 hover:bg-gray-800"
-        aria-label="increase font size"
-        onClick={() => updateZoom('increase')}
-      >
-        +
-      </button>
-      <button
-        class="bg-gray-500 text-white px-3 py-1 rounded  text-sm uppercase tracking-wide hover:bg-gray-800"
-        aria-label="reset font size"
-        onClick={() => updateZoom('reset')}
-      >
-        Reset
-      </button>
-    </div>
-  );
-};
-
-export const ZoomAlert = () => {
-  const { zoomState, updateZoom } = useZoom();
-
-  return (
-    <div>
-      <ScaleButtons></ScaleButtons>
     </div>
   );
 };

--- a/playground/components/zoomDropdown.tsx
+++ b/playground/components/zoomDropdown.tsx
@@ -1,0 +1,97 @@
+import { Icon } from '@amoutonbrady/solid-heroicons';
+import { zoomIn } from '@amoutonbrady/solid-heroicons/outline';
+import { Component, createSignal, Show } from 'solid-js';
+import useFocusOut from '../../src/hooks/useFocusOut';
+import useZoom from '../../src/hooks/useZoom';
+
+export const ZoomDropdown: Component<{ showMenu: boolean }> = (props) => {
+  const [_, { onFOBlur, onFOClick, onFOFocus }] = useFocusOut({ onToggle });
+  const [open, setOpen] = createSignal(false);
+
+  function onToggle(toggle: boolean) {
+    setOpen(toggle);
+  }
+
+  return (
+    <div class="relative" onFocusIn={onFOFocus} onFocusOut={onFOBlur} tabindex="-1">
+      <button
+        type="button"
+        class="text-black md:text-white flex flex-row space-x-2 items-center w-full md:px-3 px-2 py-2 focus:ring-1 rounded text-white opacity-80 hover:opacity-100"
+        classList={{
+          'bg-gray-900': open() && !props.showMenu,
+          'bg-gray-300': open() && props.showMenu,
+          'rounded-none	active:bg-gray-300 hover:bg-gray-300 focus:outline-none focus:highlight-none active:highlight-none focus:ring-0 active:outline-none':
+            props.showMenu,
+        }}
+        onClick={onFOClick}
+        title="Scale editor to make text larger or smaller"
+      >
+        <Icon class="h-6" path={zoomIn} />
+        <span class="text-xs md:sr-only">Scale Editor</span>
+      </button>
+      <Show when={open()}>
+        <div
+          class="absolute top-full left-1/2 bg-white text-brand-default border border-gray-900 rounded shadow  p-6 -translate-x-1/2 z-10"
+          classList={{
+            'left-1/4': props.showMenu,
+          }}
+        >
+          <ScaleButtons></ScaleButtons>
+          <div className="mt-10">
+            <label class="block my-3 cursor-pointer">
+              <input type="checkbox" class="mr-4 cursor-pointer" checked={true} />
+              Override native zoom keyboard shortcut
+            </label>
+            <label class="block my-3 cursor-pointer">
+              <input type="checkbox" class="mr-4 cursor-pointer" checked={true} />
+              Scale iframe <strong>Result</strong>
+            </label>
+          </div>
+        </div>
+      </Show>
+    </div>
+  );
+};
+
+const ScaleButtons = () => {
+  const { zoomState, updateZoom } = useZoom();
+
+  return (
+    <div class="flex">
+      <button
+        class="bg-gray-500 text-white px-3 py-1 rounded-l text-sm uppercase tracking-wide hover:bg-gray-800"
+        aria-label="decrease font size"
+        onClick={() => updateZoom('decrease')}
+      >
+        -
+      </button>
+      <div class="text-black bg-gray-100 px-3 py-1 text-sm text-center w-20 uppercase tracking-wide ">
+        {zoomState.zoom}%
+      </div>
+      <button
+        class="bg-gray-500 text-white px-3 py-1 rounded-r text-sm uppercase tracking-wide mr-4 hover:bg-gray-800"
+        aria-label="increase font size"
+        onClick={() => updateZoom('increase')}
+      >
+        +
+      </button>
+      <button
+        class="bg-gray-500 text-white px-3 py-1 rounded  text-sm uppercase tracking-wide hover:bg-gray-800"
+        aria-label="reset font size"
+        onClick={() => updateZoom('reset')}
+      >
+        Reset
+      </button>
+    </div>
+  );
+};
+
+export const ZoomAlert = () => {
+  const { zoomState, updateZoom } = useZoom();
+
+  return (
+    <div>
+      <ScaleButtons></ScaleButtons>
+    </div>
+  );
+};

--- a/playground/components/zoomDropdown.tsx
+++ b/playground/components/zoomDropdown.tsx
@@ -143,7 +143,7 @@ export const ZoomDropdown: Component<{ showMenu: boolean }> = (props) => {
                 checked={zoomState.overrideNative}
                 onChange={(e) => updateZoomSettings('overrideNative', e.currentTarget.checked)}
               />
-              Override native zoom keyboard shortcut
+              Override browser zoom keyboard shortcut
             </label>
             <label class="block my-3 cursor-pointer">
               <input

--- a/src/components/editor/index.tsx
+++ b/src/components/editor/index.tsx
@@ -24,7 +24,8 @@ const Editor: Component<Props> = (props) => {
 
   let parent!: HTMLDivElement;
   let editor: mEditor.IStandaloneCodeEditor;
-  const { zoomState: appState, updateZoom: updateAppState } = useZoom();
+
+  const { zoomState } = useZoom();
 
   const model = () => mEditor.getModel(Uri.parse(finalProps.url));
 
@@ -84,7 +85,7 @@ const Editor: Component<Props> = (props) => {
       model: null,
       automaticLayout: true,
       readOnly: finalProps.disabled,
-      fontSize: appState.fontSize,
+      fontSize: zoomState.fontSize,
       lineDecorationsWidth: 5,
       lineNumbersMinChars: 3,
       padding: { top: 15 },
@@ -113,23 +114,8 @@ const Editor: Component<Props> = (props) => {
     } else {
       setupEditor();
     }
-
-    document.addEventListener('keydown', (e) => {
-      const key = e.key;
-
-      if (!((e.ctrlKey || e.metaKey) && (key === '=' || key === '-'))) {
-        return;
-      }
-
-      e.preventDefault();
-
-      if (key === '=') {
-        updateAppState('increase');
-      } else {
-        updateAppState('decrease');
-      }
-    });
   });
+
   onCleanup(() => editor?.dispose());
 
   const updateModel = () => {
@@ -143,7 +129,7 @@ const Editor: Component<Props> = (props) => {
     mEditor.setTheme(finalProps.isDark ? 'vs-dark-plus' : 'vs-light-plus');
   });
   createEffect(() => {
-    const fontSize = appState.fontSize;
+    const fontSize = zoomState.fontSize;
 
     if (!editor) return;
 

--- a/src/components/preview.tsx
+++ b/src/components/preview.tsx
@@ -157,7 +157,7 @@ export const Preview: Component<Props> = (props) => {
   `;
 
   const styleScale = () => {
-    if (zoomState.scale === 100) return '';
+    if (zoomState.scale === 100 || !zoomState.scaleIframe) return '';
 
     return `width: ${zoomState.scale}%; height: ${zoomState.scale}%; transform: scale(${
       zoomState.zoom / 100

--- a/src/components/preview.tsx
+++ b/src/components/preview.tsx
@@ -1,9 +1,11 @@
 import { Component, createEffect, createSignal, splitProps, JSX, For, Show } from 'solid-js';
 import { Icon } from '@amoutonbrady/solid-heroicons';
 import { chevronDown, chevronRight } from '@amoutonbrady/solid-heroicons/solid';
+import useZoom from '../hooks/useZoom';
 
 export const Preview: Component<Props> = (props) => {
   const [internal, external] = splitProps(props, ['code', 'class']);
+  const { zoomState } = useZoom();
 
   let iframe!: HTMLIFrameElement;
 
@@ -154,11 +156,19 @@ export const Preview: Component<Props> = (props) => {
     </html>
   `;
 
+  const styleScale = () => {
+    if (zoomState.scale === 100) return '';
+
+    return `width: ${zoomState.scale}%; height: ${zoomState.scale}%; transform: scale(${
+      zoomState.zoom / 100
+    }); transform-origin: 0 0;`;
+  };
+
   return (
     <div
       class={`grid relative ${internal.class}`}
       {...external}
-      style="grid-template-rows: 1fr auto"
+      style={`grid-template-rows: 1fr auto; ${styleScale()}`}
     >
       <iframe
         class="overflow-auto p-2 w-full h-full dark:bg-other"

--- a/src/hooks/useFocusOut.ts
+++ b/src/hooks/useFocusOut.ts
@@ -1,0 +1,71 @@
+import { createEffect, createSignal, onCleanup } from 'solid-js';
+
+type TCb = (t: boolean) => void;
+export type FocusOutToggle = TCb;
+
+const useFocusOut = (
+  props: {
+    onToggle?: FocusOutToggle;
+    debug?: boolean;
+  } = {},
+) => {
+  const onToggle = props.onToggle;
+  const debug = props.debug || false;
+  const [toggle, setToggle] = createSignal(false);
+  let timeoutId: number | null = 0;
+  let init = false;
+
+  const onKeyDown = (e: KeyboardEvent) => {
+    if (e.key !== 'Escape') return;
+    setToggle(false);
+  };
+
+  createEffect(() => {
+    const toggleVal = toggle();
+
+    if (!init) {
+      init = true;
+      return;
+    }
+    if (!toggleVal && debug) return;
+
+    onToggle && onToggle(toggleVal);
+  });
+
+  const onFOClick = () => {
+    clearTimeout(timeoutId!);
+    timeoutId = null;
+
+    const toggleVal = toggle();
+    setToggle(!toggleVal);
+
+    if (!toggleVal) {
+      document.addEventListener('keydown', onKeyDown);
+    } else {
+      document.removeEventListener('keydown', onKeyDown);
+    }
+  };
+
+  const onFOBlur = () => {
+    const newTimeout = window.setTimeout(() => {
+      setToggle(false);
+    });
+    timeoutId = newTimeout;
+  };
+
+  const onFOFocus = () => {
+    clearTimeout(timeoutId!);
+    timeoutId = null;
+  };
+
+  onCleanup(() => {
+    document.removeEventListener('keydown', onKeyDown);
+  });
+
+  return [[toggle, setToggle], { onFOBlur, onFOFocus, onFOClick }] as [
+    [() => boolean, (v: boolean) => void],
+    { onFOBlur: () => void; onFOFocus: () => void; onFOClick: () => void },
+  ];
+};
+
+export default useFocusOut;

--- a/src/hooks/useFocusOut.ts
+++ b/src/hooks/useFocusOut.ts
@@ -29,6 +29,11 @@ const useFocusOut = (
     }
     if (!toggleVal && debug) return;
 
+    if (toggleVal) {
+      document.addEventListener('keydown', onKeyDown);
+    } else {
+      document.removeEventListener('keydown', onKeyDown);
+    }
     onToggle && onToggle(toggleVal);
   });
 
@@ -38,12 +43,6 @@ const useFocusOut = (
 
     const toggleVal = toggle();
     setToggle(!toggleVal);
-
-    if (!toggleVal) {
-      document.addEventListener('keydown', onKeyDown);
-    } else {
-      document.removeEventListener('keydown', onKeyDown);
-    }
   };
 
   const onFOBlur = () => {

--- a/src/hooks/useZoom.ts
+++ b/src/hooks/useZoom.ts
@@ -1,10 +1,9 @@
-import { batch } from 'solid-js';
 import { createStore } from 'solid-js/store';
 
 type TZoomState = {
   zoom: number;
   scaleIframe: boolean;
-  native: boolean;
+  overrideNative: boolean;
   fontSize: number;
   scale: number;
 };
@@ -20,17 +19,16 @@ const initFontSize = 15;
 const initScale = 100;
 
 const [zoomState, setZoomState] = createStore<TZoomState>({
-  native: ls ? ls.native : false,
+  overrideNative: ls ? ls.overrideNative : true,
   fontSize: ls ? ls.fontSize : initFontSize,
   scale: ls ? ls.scale : initScale,
   zoom: ls ? ls.zoom : 100,
   scaleIframe: ls ? ls.scaleIframe : true,
 });
-console.log(JSON.parse(JSON.stringify(zoomState)));
 
 const useZoom = () => {
-  const updateZoom = (input: 'increase' | 'decrease' | 'reset') => {
-    let { zoom, fontSize, scale, native, scaleIframe } = zoomState;
+  const updateZoomScale = (input: 'increase' | 'decrease' | 'reset') => {
+    let { zoom, fontSize, scale } = zoomState;
     const max = 200;
     const min = 40;
 
@@ -51,14 +49,34 @@ const useZoom = () => {
     fontSize = (initFontSize * zoom) / 100;
     scale = (initScale / zoom) * 100;
 
-    localStorage.setItem(
-      'zoomState',
-      JSON.stringify({ zoom, fontSize, scale, native, scaleIframe }),
-    );
+    localStorage.setItem('zoomState', JSON.stringify({ ...zoomState, zoom, fontSize, scale }));
 
     setZoomState({ ...zoomState, fontSize, zoom, scale });
   };
 
-  return { zoomState, updateZoom };
+  const updateZoomSettings = (
+    input: keyof Pick<TZoomState, 'overrideNative' | 'scaleIframe'>,
+    value: boolean,
+  ) => {
+    let { overrideNative, scaleIframe } = zoomState;
+
+    switch (input) {
+      case 'overrideNative':
+        overrideNative = value;
+        break;
+      case 'scaleIframe':
+        scaleIframe = value;
+        break;
+    }
+
+    localStorage.setItem(
+      'zoomState',
+      JSON.stringify({ ...zoomState, overrideNative, scaleIframe }),
+    );
+
+    setZoomState({ ...zoomState, overrideNative, scaleIframe });
+  };
+
+  return { zoomState, updateZoomScale, updateZoomSettings };
 };
 export default useZoom;

--- a/src/hooks/useZoom.ts
+++ b/src/hooks/useZoom.ts
@@ -1,0 +1,64 @@
+import { batch } from 'solid-js';
+import { createStore } from 'solid-js/store';
+
+type TZoomState = {
+  zoom: number;
+  scaleIframe: boolean;
+  native: boolean;
+  fontSize: number;
+  scale: number;
+};
+
+const getLS = () => {
+  const result = localStorage.getItem('zoomState');
+  if (result == null) return null;
+  return JSON.parse(result) as TZoomState;
+};
+
+const ls = getLS();
+const initFontSize = 15;
+const initScale = 100;
+
+const [zoomState, setZoomState] = createStore<TZoomState>({
+  native: ls ? ls.native : false,
+  fontSize: ls ? ls.fontSize : initFontSize,
+  scale: ls ? ls.scale : initScale,
+  zoom: ls ? ls.zoom : 100,
+  scaleIframe: ls ? ls.scaleIframe : true,
+});
+console.log(JSON.parse(JSON.stringify(zoomState)));
+
+const useZoom = () => {
+  const updateZoom = (input: 'increase' | 'decrease' | 'reset') => {
+    let { zoom, fontSize, scale, native, scaleIframe } = zoomState;
+    const max = 200;
+    const min = 40;
+
+    switch (input) {
+      case 'increase':
+        zoom += 10;
+        break;
+      case 'decrease':
+        zoom -= 10;
+        break;
+      default:
+        zoom = 100;
+        break;
+    }
+
+    if (zoom > max) zoom = max;
+    if (zoom < min) zoom = min;
+    fontSize = (initFontSize * zoom) / 100;
+    scale = (initScale / zoom) * 100;
+
+    localStorage.setItem(
+      'zoomState',
+      JSON.stringify({ zoom, fontSize, scale, native, scaleIframe }),
+    );
+
+    setZoomState({ ...zoomState, fontSize, zoom, scale });
+  };
+
+  return { zoomState, updateZoom };
+};
+export default useZoom;


### PR DESCRIPTION
This is related to the recent discussion on discord on how some things on this playground is not ideal for video presentation.

One such thing that this PR addresses is preserving visual space when scaling up the page, and only scaling the important UI that users only care about during video presentation, which is the code (Monaco editor) , and the page result (Result iframe/panel).

![Peek 2021-07-28 08-15](https://user-images.githubusercontent.com/29286430/127348471-3ee0eff8-d45c-4925-952f-5561e100f383.gif)


Here's a screenshot of current website when zoomed in 150%. As you can see the Header takes up a lot of valuable space. Other smaller UI elements when all added together take up space as well.
![Screenshot from 2021-07-27 23-12-06](https://user-images.githubusercontent.com/29286430/127274064-5431b705-6950-48cf-ad98-326e88bf9e7e.png)

Here's the alternative zoomed in elements when artificially zoomed in "150%"
![Screenshot from 2021-07-27 23-12-03](https://user-images.githubusercontent.com/29286430/127274211-83d42016-1b73-42dd-9b57-5fb1af3acd43.png)


## What's Added

Zoom button in Header
![malloney](https://user-images.githubusercontent.com/29286430/127275670-0252ff2b-121c-4062-ad5e-020199c96f33.png)

## How is scaling done?
It updates Monaco's editor font-size `editor.updateOptions({ fontSize });`. 

For the Result panel, it's done via transform property and width/height.
```css
.container {
  transform: scale(1.2);
  transform-origin: 0 0;
  width: 88.33%;
  height: 88.33%;
}
```

There is a CSS property [`zoom`](https://developer.mozilla.org/en-US/docs/Web/CSS/zoom), but it's experimental, is not supported by Firefox, and I couldn't get it to work on an iframe.

## Dropdown Behavior
The button when selected, opens a dropdown with the zoom settings. The dropdown has a "focusout" behavior where pressing Escape key or clicking/focusing outside of the container will close the dropdown.

![Peek 2021-07-28 00-31](https://user-images.githubusercontent.com/29286430/127282469-1de2c70f-d071-4092-8836-4011ae6f6a9a.gif)

When pressing `Ctrl+` or `Ctrl-`, the dropdown opens temporarily (1200ms) for immediate feedback. 
The dropdown becomes the active element and is `focus()`. Previous focused element will regain `focus()` when user presses Escape key or dropdown closes after timeout( as long as dropdown hasn't been interacted with, such as Tabbing or selecting inside it or mouse cursor moves within it)

## Settings
![Screenshot from 2021-07-27 23-44-26](https://user-images.githubusercontent.com/29286430/127279367-76563d62-0be8-415e-afd1-7e0d53fc12df.png)
There's zoom buttons such as `increase`, `decrease`, and `reset`. 

If users are not happy how the default page scaling shortcuts were overriden, there's an option to disable that.

If the user is only interested in scaling Monaco's text, you can disable scaling the Result iframe.

Result iframe is scaled
![Screenshot from 2021-07-27 23-43-30](https://user-images.githubusercontent.com/29286430/127279474-0b1c7060-4ca9-41ca-a75e-0d55d1fd0760.png)
Result iframe is not scaled
![Screenshot from 2021-07-27 23-43-43](https://user-images.githubusercontent.com/29286430/127279593-28170d2e-e282-4a41-afe1-ac72a5580284.png)
