### PR TITLE
Set dark theme to dropdown

### DIFF
--- a/playground/components/zoomDropdown.tsx
+++ b/playground/components/zoomDropdown.tsx
@@ -117,7 +117,7 @@ export const ZoomDropdown: Component<{ showMenu: boolean }> = (props) => {
             >
               -
             </button>
-            <div class="text-black bg-gray-100 dark:bg-gray-300 px-3 py-1 text-sm text-center w-20 uppercase tracking-wide ">
+            <div class="text-black bg-gray-100 dark:bg-gray-200 px-3 py-1 text-sm text-center w-20 uppercase tracking-wide ">
               <span>{zoomState.zoom}%</span>
             </div>
             <button

--- a/playground/components/zoomDropdown.tsx
+++ b/playground/components/zoomDropdown.tsx
@@ -104,14 +104,14 @@ export const ZoomDropdown: Component<{ showMenu: boolean }> = (props) => {
       </button>
       <Show when={toggle()}>
         <div
-          class="absolute top-full left-1/2 bg-white text-brand-default border border-gray-900 rounded shadow  p-6 -translate-x-1/2 z-10"
+          class="absolute top-full left-1/2 bg-white dark:bg-gray-700 text-brand-default border border-gray-900 rounded shadow  p-6 -translate-x-1/2 z-10"
           classList={{
             'left-1/4': props.showMenu,
           }}
         >
           <div class="flex">
             <button
-              class="bg-gray-500 text-white px-3 py-1 rounded-l text-sm uppercase tracking-wide hover:bg-gray-800"
+              class="bg-gray-500 text-white px-3 py-1 rounded-l text-sm uppercase tracking-wide hover:bg-gray-800 dark:hover:bg-black"
               aria-label="decrease font size"
               onClick={() => updateZoomScale('decrease')}
             >
@@ -121,14 +121,14 @@ export const ZoomDropdown: Component<{ showMenu: boolean }> = (props) => {
               {zoomState.zoom}%
             </div>
             <button
-              class="bg-gray-500 text-white px-3 py-1 rounded-r text-sm uppercase tracking-wide mr-4 hover:bg-gray-800"
+              class="bg-gray-500 text-white px-3 py-1 rounded-r text-sm uppercase tracking-wide mr-4 hover:bg-gray-800 dark:hover:bg-black"
               aria-label="increase font size"
               onClick={() => updateZoomScale('increase')}
             >
               +
             </button>
             <button
-              class="bg-gray-500 text-white px-3 py-1 rounded  text-sm uppercase tracking-wide hover:bg-gray-800"
+              class="bg-gray-500 text-white px-3 py-1 rounded  text-sm uppercase tracking-wide hover:bg-gray-800 dark:hover:bg-black"
               aria-label="reset font size"
               onClick={() => updateZoomScale('reset')}
             >
@@ -136,7 +136,7 @@ export const ZoomDropdown: Component<{ showMenu: boolean }> = (props) => {
             </button>
           </div>
           <div className="mt-10">
-            <label class="block my-3 cursor-pointer">
+            <label class="block my-3 cursor-pointer dark:text-white">
               <input
                 type="checkbox"
                 class="mr-4 cursor-pointer"
@@ -145,7 +145,7 @@ export const ZoomDropdown: Component<{ showMenu: boolean }> = (props) => {
               />
               Override browser zoom keyboard shortcut
             </label>
-            <label class="block my-3 cursor-pointer">
+            <label class="block my-3 cursor-pointer dark:text-white">
               <input
                 type="checkbox"
                 class="mr-4 cursor-pointer"

--- a/playground/components/zoomDropdown.tsx
+++ b/playground/components/zoomDropdown.tsx
@@ -117,8 +117,8 @@ export const ZoomDropdown: Component<{ showMenu: boolean }> = (props) => {
             >
               -
             </button>
-            <div class="text-black bg-gray-100 px-3 py-1 text-sm text-center w-20 uppercase tracking-wide ">
-              {zoomState.zoom}%
+            <div class="text-black bg-gray-100 dark:bg-gray-300 px-3 py-1 text-sm text-center w-20 uppercase tracking-wide ">
+              <span>{zoomState.zoom}%</span>
             </div>
             <button
               class="bg-gray-500 text-white px-3 py-1 rounded-r text-sm uppercase tracking-wide mr-4 hover:bg-gray-800 dark:hover:bg-black"


### PR DESCRIPTION
I forgot to set dark theme colors for zoom dropdown.
![2021-08-02_12-06](https://user-images.githubusercontent.com/29286430/127898555-96e351c7-c714-4018-acf2-a69541edeaa3.png)

![Screenshot from 2021-08-02 12-09-14](https://user-images.githubusercontent.com/29286430/127898787-dd071c67-511c-4075-a95d-3fe7573f17b0.png)


When buttons are hovered, its background is set to black
![Screenshot from 2021-08-02 12-07-18](https://user-images.githubusercontent.com/29286430/127898570-82e4cbe3-5881-4136-b3aa-7f89c9030468.png)

