### PR TITLE
Add dark theme to grid-resizer

### DIFF
--- a/src/components/gridResizer/dot.tsx
+++ b/src/components/gridResizer/dot.tsx
@@ -1,5 +1,13 @@
-import type { Component, JSX } from 'solid-js';
+import type { Component } from 'solid-js';
 
-export const Dot: Component = () => {
-  return <span class="m-1 w-1 h-1 rounded-full bg-blueGray-200" />;
+export const Dot: Component<{ isDragging: boolean }> = (props) => {
+  return (
+    <span
+      class="m-1 w-1 h-1 rounded-full bg-blueGray-300 dark:bg-blueGray-600 dark:group-hover:bg-blueGray-200"
+      classList={{
+        'bg-blueGray-200': props.isDragging,
+        'dark:bg-blueGray-200': props.isDragging,
+      }}
+    />
+  );
 };

--- a/src/components/gridResizer/gridResizer.tsx
+++ b/src/components/gridResizer/gridResizer.tsx
@@ -1,11 +1,4 @@
-import {
-  Component,
-  JSX,
-  splitProps,
-  createSignal,
-  createEffect,
-  onCleanup,
-} from 'solid-js';
+import { Component, JSX, splitProps, createSignal, createEffect, onCleanup } from 'solid-js';
 import { throttle } from '../../utils/throttle';
 import { Dot } from './dot';
 
@@ -72,9 +65,14 @@ export const GridResizer: Component<GridResizerProps> = (props) => {
     }
   });
 
-  const baseClasses = 'justify-center items-center border-blueGray-200 hover:bg-brand-default';
+  const baseClasses =
+    'justify-center group items-center border-blueGray-200 dark:border-blueGray-700 dark:bg-gray-900 hover:bg-brand-default dark:hover:bg-brand-default';
   const resizingClasses = () =>
-    `${isDragging() ? 'bg-brand-default' : 'bg-blueGray-50 dark:bg-blueGray-800'}`;
+    `${
+      isDragging()
+        ? 'bg-brand-default dark:bg-brand-default'
+        : 'bg-blueGray-50 dark:bg-blueGray-800'
+    }`;
   const directionClasses = () =>
     local.direction === 'horizontal'
       ? `flex-col cursor-col-resize border-l-2 border-r-2 hidden${
@@ -95,9 +93,9 @@ export const GridResizer: Component<GridResizerProps> = (props) => {
         }
       />
       <div ref={setRef} class={classes()} {...other}>
-        <Dot />
-        <Dot />
-        <Dot />
+        <Dot isDragging={isDragging()} />
+        <Dot isDragging={isDragging()} />
+        <Dot isDragging={isDragging()} />
       </div>
     </>
   );

--- a/src/components/gridResizer/gridResizer.tsx
+++ b/src/components/gridResizer/gridResizer.tsx
@@ -66,12 +66,10 @@ export const GridResizer: Component<GridResizerProps> = (props) => {
   });
 
   const baseClasses =
-    'justify-center group items-center border-blueGray-200 dark:border-blueGray-700 dark:bg-gray-900 hover:bg-brand-default dark:hover:bg-brand-default';
+    'justify-center group items-center border-blueGray-200 dark:border-blueGray-700 hover:bg-brand-default dark:hover:bg-brand-default';
   const resizingClasses = () =>
     `${
-      isDragging()
-        ? 'bg-brand-default dark:bg-brand-default'
-        : 'bg-blueGray-50 dark:bg-blueGray-800'
+      isDragging() ? 'bg-brand-default dark:bg-brand-default' : 'bg-blueGray-50 dark:bg-gray-900'
     }`;
   const directionClasses = () =>
     local.direction === 'horizontal'

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,11 +3,7 @@ const theme = require('tailwindcss/defaultTheme');
 
 module.exports = {
   mode: 'jit',
-  purge: [
-    "./src/**/*.{tsx,ts,css}",
-    "./playground/**/*.{tsx,ts,css}",
-    "./index.html"
-  ],
+  purge: ['./src/**/*.{tsx,ts,css}', './playground/**/*.{tsx,ts,css}', './index.html'],
   theme: {
     extend: {
       colors: {
@@ -18,7 +14,7 @@ module.exports = {
           medium: '#446b9e',
           light: '#4f88c6',
         },
-        other: '#1e1e1e'
+        other: '#1e1e1e',
       },
       fontFamily: {
         // This font doesn't render properly, it seems it has a line-height issue
@@ -29,10 +25,15 @@ module.exports = {
       },
       cursor: {
         'col-resize': 'col-resize',
-        'row-resize': 'row-resize'
-      }
+        'row-resize': 'row-resize',
+      },
     },
   },
   darkMode: 'class',
+  variants: {
+    extend: {
+      backgroundColor: ['group-hover'],
+    },
+  },
   plugins: [require('@tailwindcss/forms')],
 };


### PR DESCRIPTION
The `grid-resizer` element doesn't have dark theme colors.

Currently the colors still use the light theme palette. 
![2021-08-02_16-48](https://user-images.githubusercontent.com/29286430/127928214-13bcdc18-38ab-4c64-bf6b-05f0ff632130.png)

Dark theme colors
![2021-08-02_16-28](https://user-images.githubusercontent.com/29286430/127928296-270497c1-b403-4347-b219-10550997356c.png)

When dragging.
![Peek 2021-08-02 16-42](https://user-images.githubusercontent.com/29286430/127928339-90c32d5f-2816-4d0e-920a-64bf27e7309d.gif)

In order to set the `Dots` color upon hover, I add to add a class variant in the tailwind config, which I named `group-hover` based from the [tailwind docs](https://tailwindcss.com/docs/hover-focus-and-other-states#group-hover)
![Screenshot from 2021-08-02 16-51-03](https://user-images.githubusercontent.com/29286430/127928627-c461c09b-dd49-4b25-8583-f8b5969ed75b.png)

