### PR TITLE
Add dark theme on UIs and restore Compiler Mode

### DIFF
--- a/playground/components/header.tsx
+++ b/playground/components/header.tsx
@@ -87,18 +87,18 @@ export const Header: Component<{
           class="z-10"
         >
           <div
-            class="md:items-center md:space-x-2 md:flex md:flex-row"
+            class="md:items-center md:space-x-2 md:flex md:flex-row text-black dark:text-white"
             classList={{
-              'shadow-md flex flex-col justify-center bg-white': showMenu(),
+              'shadow-md flex flex-col justify-center bg-white dark:bg-gray-700': showMenu(),
               hidden: !showMenu(),
             }}
           >
             <button
               type="button"
               onClick={props.toggleDark}
-              class="text-black md:text-white flex flex-row space-x-2 items-center md:px-3 px-2 py-2 focus:outline-none focus:ring-1 rounded text-white opacity-80 hover:opacity-100"
+              class="md:text-white flex flex-row space-x-2 items-center md:px-3 px-2 py-2 focus:outline-none focus:ring-1 rounded opacity-80 hover:opacity-100"
               classList={{
-                'rounded-none	active:bg-gray-300 hover:bg-gray-300 focus:outline-none focus:highlight-none active:highlight-none focus:ring-0 active:outline-none':
+                'rounded-none	active:bg-gray-300 hover:bg-gray-300 dark:hover:text-black focus:outline-none focus:highlight-none active:highlight-none focus:ring-0 active:outline-none':
                   showMenu(),
               }}
               title="Toggle dark mode"
@@ -110,9 +110,9 @@ export const Header: Component<{
             </button>
 
             <label
-              class="text-black md:text-white flex flex-row space-x-2 items-center md:px-3 px-2 py-2 focus:outline-none focus:ring-1 rounded text-white opacity-80 hover:opacity-100 cursor-pointer"
+              class="md:text-white flex flex-row space-x-2 items-center md:px-3 px-2 py-2 focus:outline-none focus:ring-1 rounded opacity-80 hover:opacity-100 cursor-pointer"
               classList={{
-                'rounded-none	active:bg-gray-300 hover:bg-gray-300 focus:outline-none focus:highlight-none active:highlight-none focus:ring-0 active:outline-none':
+                'rounded-none	active:bg-gray-300 hover:bg-gray-300 dark:hover:text-black focus:outline-none focus:highlight-none active:highlight-none focus:ring-0 active:outline-none':
                   showMenu(),
               }}
               title="Import from JSON"
@@ -125,9 +125,9 @@ export const Header: Component<{
             <button
               type="button"
               onClick={() => exportToJSON(props.tabs)}
-              class="text-black md:text-white flex flex-row space-x-2 items-center md:px-3 px-2 py-2 focus:outline-none focus:ring-1 rounded text-white opacity-80 hover:opacity-100"
+              class="md:text-white flex flex-row space-x-2 items-center md:px-3 px-2 py-2 focus:outline-none focus:ring-1 rounded opacity-80 hover:opacity-100"
               classList={{
-                'rounded-none	active:bg-gray-300 hover:bg-gray-300 focus:outline-none focus:highlight-none active:highlight-none focus:ring-0 active:outline-none':
+                'rounded-none	active:bg-gray-300 hover:bg-gray-300 dark:hover:text-black focus:outline-none focus:highlight-none active:highlight-none focus:ring-0 active:outline-none':
                   showMenu(),
               }}
               title="Export to JSON"
@@ -141,9 +141,9 @@ export const Header: Component<{
             <button
               type="button"
               onClick={() => exportToCsb(props.tabs)}
-              class="text-black md:text-white flex flex-row space-x-2 items-center md:px-3 px-2 py-2 focus:outline-none focus:ring-1 rounded text-white opacity-80 hover:opacity-100"
+              class="md:text-white flex flex-row space-x-2 items-center md:px-3 px-2 py-2 focus:outline-none focus:ring-1 rounded opacity-80 hover:opacity-100"
               classList={{
-                'rounded-none	active:bg-gray-300 hover:bg-gray-300 focus:outline-none focus:highlight-none active:highlight-none focus:ring-0 active:outline-none':
+                'rounded-none	active:bg-gray-300 hover:bg-gray-300 dark:hover:text-black focus:outline-none focus:highlight-none active:highlight-none focus:ring-0 active:outline-none':
                   showMenu(),
               }}
               title="Export to CodeSandbox"
@@ -161,11 +161,11 @@ export const Header: Component<{
             <button
               type="button"
               onClick={shareLink}
-              class="text-black md:text-white flex flex-row space-x-2 items-center md:px-3 px-2 py-2 focus:outline-none focus:ring-1 rounded"
+              class="md:text-white flex flex-row space-x-2 items-center md:px-3 px-2 py-2 focus:outline-none focus:ring-1 rounded"
               classList={{
                 'opacity-80 hover:opacity-100': !copy(),
                 'text-green-100': copy() && !showMenu(),
-                'rounded-none	active:bg-gray-300 hover:bg-gray-300 focus:outline-none focus:highlight-none active:highlight-none focus:ring-0 active:outline-none':
+                'rounded-none	active:bg-gray-300 hover:bg-gray-300 dark:hover:text-black focus:outline-none focus:highlight-none active:highlight-none focus:ring-0 active:outline-none':
                   showMenu(),
               }}
               title="Share with a minified link"

--- a/playground/components/zoomDropdown.tsx
+++ b/playground/components/zoomDropdown.tsx
@@ -88,11 +88,11 @@ export const ZoomDropdown: Component<{ showMenu: boolean }> = (props) => {
     >
       <button
         type="button"
-        class="text-black md:text-white flex flex-row space-x-2 items-center w-full md:px-3 px-2 py-2 focus:ring-1 rounded text-white opacity-80 hover:opacity-100"
+        class="dark:text-white md:text-white flex flex-row space-x-2 items-center w-full md:px-3 px-2 py-2 focus:ring-1 rounded opacity-80 hover:opacity-100"
         classList={{
           'bg-gray-900': toggle() && !props.showMenu,
-          'bg-gray-300': toggle() && props.showMenu,
-          'rounded-none	active:bg-gray-300 hover:bg-gray-300 focus:outline-none focus:highlight-none active:highlight-none focus:ring-0 active:outline-none':
+          'bg-gray-300 dark:text-black': toggle() && props.showMenu,
+          'rounded-none	active:bg-gray-300 hover:bg-gray-300 dark:hover:text-black focus:outline-none focus:highlight-none active:highlight-none focus:ring-0 active:outline-none':
             props.showMenu,
         }}
         onClick={onFOClick}

--- a/playground/components/zoomDropdown.tsx
+++ b/playground/components/zoomDropdown.tsx
@@ -118,7 +118,7 @@ export const ZoomDropdown: Component<{ showMenu: boolean }> = (props) => {
               -
             </button>
             <div class="text-black bg-gray-100 dark:bg-gray-200 px-3 py-1 text-sm text-center w-20 uppercase tracking-wide ">
-              <span>{zoomState.zoom}%</span>
+              {zoomState.zoom}%
             </div>
             <button
               class="bg-gray-500 text-white px-3 py-1 rounded-r text-sm uppercase tracking-wide mr-4 hover:bg-gray-800 dark:hover:bg-black"

--- a/playground/components/zoomDropdown.tsx
+++ b/playground/components/zoomDropdown.tsx
@@ -117,7 +117,7 @@ export const ZoomDropdown: Component<{ showMenu: boolean }> = (props) => {
             >
               -
             </button>
-            <div class="text-black bg-gray-100 dark:bg-gray-300 px-3 py-1 text-sm text-center w-20 uppercase tracking-wide ">
+            <div class="text-black bg-gray-100 dark:bg-gray-200 px-3 py-1 text-sm text-center w-20 uppercase tracking-wide ">
               <span>{zoomState.zoom}%</span>
             </div>
             <button

--- a/playground/components/zoomDropdown.tsx
+++ b/playground/components/zoomDropdown.tsx
@@ -104,14 +104,14 @@ export const ZoomDropdown: Component<{ showMenu: boolean }> = (props) => {
       </button>
       <Show when={toggle()}>
         <div
-          class="absolute top-full left-1/2 bg-white text-brand-default border border-gray-900 rounded shadow  p-6 -translate-x-1/2 z-10"
+          class="absolute top-full left-1/2 bg-white dark:bg-gray-700 text-brand-default border border-gray-900 rounded shadow  p-6 -translate-x-1/2 z-10"
           classList={{
             'left-1/4': props.showMenu,
           }}
         >
           <div class="flex">
             <button
-              class="bg-gray-500 text-white px-3 py-1 rounded-l text-sm uppercase tracking-wide hover:bg-gray-800"
+              class="bg-gray-500 text-white px-3 py-1 rounded-l text-sm uppercase tracking-wide hover:bg-gray-800 dark:hover:bg-black"
               aria-label="decrease font size"
               onClick={() => updateZoomScale('decrease')}
             >
@@ -121,14 +121,14 @@ export const ZoomDropdown: Component<{ showMenu: boolean }> = (props) => {
               {zoomState.zoom}%
             </div>
             <button
-              class="bg-gray-500 text-white px-3 py-1 rounded-r text-sm uppercase tracking-wide mr-4 hover:bg-gray-800"
+              class="bg-gray-500 text-white px-3 py-1 rounded-r text-sm uppercase tracking-wide mr-4 hover:bg-gray-800 dark:hover:bg-black"
               aria-label="increase font size"
               onClick={() => updateZoomScale('increase')}
             >
               +
             </button>
             <button
-              class="bg-gray-500 text-white px-3 py-1 rounded  text-sm uppercase tracking-wide hover:bg-gray-800"
+              class="bg-gray-500 text-white px-3 py-1 rounded  text-sm uppercase tracking-wide hover:bg-gray-800 dark:hover:bg-black"
               aria-label="reset font size"
               onClick={() => updateZoomScale('reset')}
             >
@@ -136,7 +136,7 @@ export const ZoomDropdown: Component<{ showMenu: boolean }> = (props) => {
             </button>
           </div>
           <div className="mt-10">
-            <label class="block my-3 cursor-pointer">
+            <label class="block my-3 cursor-pointer dark:text-white">
               <input
                 type="checkbox"
                 class="mr-4 cursor-pointer"
@@ -145,7 +145,7 @@ export const ZoomDropdown: Component<{ showMenu: boolean }> = (props) => {
               />
               Override browser zoom keyboard shortcut
             </label>
-            <label class="block my-3 cursor-pointer">
+            <label class="block my-3 cursor-pointer dark:text-white">
               <input
                 type="checkbox"
                 class="mr-4 cursor-pointer"

--- a/playground/components/zoomDropdown.tsx
+++ b/playground/components/zoomDropdown.tsx
@@ -117,8 +117,8 @@ export const ZoomDropdown: Component<{ showMenu: boolean }> = (props) => {
             >
               -
             </button>
-            <div class="text-black bg-gray-100 px-3 py-1 text-sm text-center w-20 uppercase tracking-wide ">
-              {zoomState.zoom}%
+            <div class="text-black bg-gray-100 dark:bg-gray-300 px-3 py-1 text-sm text-center w-20 uppercase tracking-wide ">
+              <span>{zoomState.zoom}%</span>
             </div>
             <button
               class="bg-gray-500 text-white px-3 py-1 rounded-r text-sm uppercase tracking-wide mr-4 hover:bg-gray-800 dark:hover:bg-black"

--- a/src/components/gridResizer/dot.tsx
+++ b/src/components/gridResizer/dot.tsx
@@ -1,5 +1,13 @@
-import type { Component, JSX } from 'solid-js';
+import type { Component } from 'solid-js';
 
-export const Dot: Component = () => {
-  return <span class="m-1 w-1 h-1 rounded-full bg-blueGray-200" />;
+export const Dot: Component<{ isDragging: boolean }> = (props) => {
+  return (
+    <span
+      class="m-1 w-1 h-1 rounded-full bg-blueGray-300 dark:bg-blueGray-600 dark:group-hover:bg-blueGray-200"
+      classList={{
+        'bg-blueGray-200': props.isDragging,
+        'dark:bg-blueGray-200': props.isDragging,
+      }}
+    />
+  );
 };

--- a/src/components/gridResizer/gridResizer.tsx
+++ b/src/components/gridResizer/gridResizer.tsx
@@ -1,11 +1,4 @@
-import {
-  Component,
-  JSX,
-  splitProps,
-  createSignal,
-  createEffect,
-  onCleanup,
-} from 'solid-js';
+import { Component, JSX, splitProps, createSignal, createEffect, onCleanup } from 'solid-js';
 import { throttle } from '../../utils/throttle';
 import { Dot } from './dot';
 
@@ -72,9 +65,12 @@ export const GridResizer: Component<GridResizerProps> = (props) => {
     }
   });
 
-  const baseClasses = 'justify-center items-center border-blueGray-200 hover:bg-brand-default';
+  const baseClasses =
+    'justify-center group items-center border-blueGray-200 dark:border-blueGray-700 hover:bg-brand-default dark:hover:bg-brand-default';
   const resizingClasses = () =>
-    `${isDragging() ? 'bg-brand-default' : 'bg-blueGray-50 dark:bg-blueGray-800'}`;
+    `${
+      isDragging() ? 'bg-brand-default dark:bg-brand-default' : 'bg-blueGray-50 dark:bg-gray-900'
+    }`;
   const directionClasses = () =>
     local.direction === 'horizontal'
       ? `flex-col cursor-col-resize border-l-2 border-r-2 hidden${
@@ -95,9 +91,9 @@ export const GridResizer: Component<GridResizerProps> = (props) => {
         }
       />
       <div ref={setRef} class={classes()} {...other}>
-        <Dot />
-        <Dot />
-        <Dot />
+        <Dot isDragging={isDragging()} />
+        <Dot isDragging={isDragging()} />
+        <Dot isDragging={isDragging()} />
       </div>
     </>
   );

--- a/src/components/repl.tsx
+++ b/src/components/repl.tsx
@@ -474,7 +474,7 @@ export const Repl: Component<ReplProps> = (props) => {
               showActionBar={props.actionBar}
             />
 
-            <div class="bg-white dark:bg-blueGray-800 p-5 hidden md:block">
+            <div class="bg-white dark:bg-blueGray-800 p-5">
               <label class="font-semibold text-sm uppercase">Compile mode</label>
 
               <div class="mt-1 space-y-1 text-sm">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,11 +3,7 @@ const theme = require('tailwindcss/defaultTheme');
 
 module.exports = {
   mode: 'jit',
-  purge: [
-    "./src/**/*.{tsx,ts,css}",
-    "./playground/**/*.{tsx,ts,css}",
-    "./index.html"
-  ],
+  purge: ['./src/**/*.{tsx,ts,css}', './playground/**/*.{tsx,ts,css}', './index.html'],
   theme: {
     extend: {
       colors: {
@@ -18,7 +14,7 @@ module.exports = {
           medium: '#446b9e',
           light: '#4f88c6',
         },
-        other: '#1e1e1e'
+        other: '#1e1e1e',
       },
       fontFamily: {
         // This font doesn't render properly, it seems it has a line-height issue
@@ -29,10 +25,15 @@ module.exports = {
       },
       cursor: {
         'col-resize': 'col-resize',
-        'row-resize': 'row-resize'
-      }
+        'row-resize': 'row-resize',
+      },
     },
   },
   darkMode: 'class',
+  variants: {
+    extend: {
+      backgroundColor: ['group-hover'],
+    },
+  },
   plugins: [require('@tailwindcss/forms')],
 };


### PR DESCRIPTION
## Dark theme on Zoom Dropdown
![Screenshot from 2021-08-02 19-33-56](https://user-images.githubusercontent.com/29286430/127940708-47cd3f0b-fbd7-4579-a371-2d968d5d6c90.png)

## Dark theme on Header Dropdown
Background is dark with white text, while hover/active state is light background with black text.
![Screenshot from 2021-08-02 19-33-16](https://user-images.githubusercontent.com/29286430/127940713-8d868c58-ee4d-45a8-8b8e-199391e2265e.png)


## Dark theme on Grid Resizer
![Screenshot from 2021-08-02 19-37-45](https://user-images.githubusercontent.com/29286430/127941048-66f1d273-e52b-460b-b79a-3562fa3e5ef5.png)
![foo](https://user-images.githubusercontent.com/29286430/127967743-55dbac03-9781-4d81-8599-0726f5797af5.png)
The current grid resizer white border color has too much contrast. Compare that to the current Light theme, the colors are have low contrast but is noticeable enough. This Dark theme gride resizer matches the contrast of the Light theme, and is comfortable to the eyes.

#### When hovered/dragged
![Screenshot from 2021-08-02 19-31-25](https://user-images.githubusercontent.com/29286430/127941072-796fe01c-9c9a-4813-8a7a-80571fa13dd8.png)
![Peek 2021-08-02 19-32](https://user-images.githubusercontent.com/29286430/127941080-2d29e1ca-c1d0-4e54-ba85-7eb8275be471.gif)
In order to make the `Dot`s Component in the resizer to change to light background when hovering, I had to had add `group` class variant in the tailwind config in order to use [`group-hover`](https://tailwindcss.com/docs/hover-focus-and-other-states#group-hover).




## Restore missing Compiler Mode
One the recent PR's may have accidentally removed Compiler Mode UI in mobile view. This PR restores it in mobile view.
![Screenshot from 2021-08-02 19-55-58](https://user-images.githubusercontent.com/29286430/127941206-b7281b2c-752a-4722-ac97-e7d053a27b87.png)

