### PR TITLE
chore: format missed files

### DIFF
--- a/src/components/monacoTabs.tsx
+++ b/src/components/monacoTabs.tsx
@@ -7,7 +7,9 @@ const MonacoTabs: Component<{ tabs: Tab[]; compiled: string }> = (props) => {
   const fileUri = Uri.parse(`file:///output_dont_import.tsx`);
   const model = editor.createModel('', 'typescript', fileUri);
   createEffect(() => {
-    model.setValue(props.compiled.replace(/(https:\/\/cdn.skypack.dev\/)|(@[0-9][0-9.\-a-z]+)/g, ''));
+    model.setValue(
+      props.compiled.replace(/(https:\/\/cdn.skypack.dev\/)|(@[0-9][0-9.\-a-z]+)/g, ''),
+    );
   });
   onCleanup(() => model.dispose());
 


### PR DESCRIPTION
The file `src/components/monacoTabs.tsx` was not formatted when it was added.
Running `pnpm format` performed formatting.