### PR TITLE
chore: gitignore non pnpm files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ dist
 lib
 .parcel-cache
 .env
+
+.yarn*
+yarn.lock
+package-lock.json


### PR DESCRIPTION
This project switched to pnpm in commit https://github.com/solidjs/solid-playground/commit/ffa8f15ba6d70d32691d86474f8dc3395e0ab1ed#diff-51e4f558fae534656963876761c95b83b6ef5da5103c4adef6768219ed76c2de

Ignoring non pnpm files ensures that those files are not mistakenly commited.