### PR TITLE
feat: choose theme based on prefers-color-scheme on load

### DIFF
--- a/playground/app.tsx
+++ b/playground/app.tsx
@@ -24,6 +24,7 @@ import { isValidUrl } from './utils/isValidUrl';
 import CompilerWorker from '../src/workers/compiler?worker';
 import FormatterWorker from '../src/workers/formatter?worker';
 import useZoom from '../src/hooks/useZoom';
+import { isDarkTheme } from './utils/isDarkTheme';
 
 (window as any).MonacoEnvironment = {
   getWorker(_moduleId: unknown, label: string) {
@@ -96,7 +97,7 @@ export const App = (): JSX.Element => {
     'noEditableTabs',
   ].map((key) => key in params);
 
-  const [dark, setDark] = createSignal(localStorage.getItem('dark') === 'true');
+  const [dark, setDark] = createSignal(isDarkTheme());
 
   createEffect(() => {
     const action = dark() ? 'add' : 'remove';

--- a/playground/app.tsx
+++ b/playground/app.tsx
@@ -102,7 +102,6 @@ export const App = (): JSX.Element => {
   createEffect(() => {
     const action = dark() ? 'add' : 'remove';
     document.body.classList[action]('dark');
-    localStorage.setItem('dark', String(dark()));
   });
 
   const header = !noHeader;
@@ -137,7 +136,11 @@ export const App = (): JSX.Element => {
         children={
           <Header
             dark={dark()}
-            toggleDark={() => setDark(!dark())}
+            toggleDark={() => {
+              const toggledValue = !dark();
+              setDark(toggledValue);
+              localStorage.setItem('dark', String(toggledValue));
+            }}
             isHorizontal={isHorizontal}
             tabs={tabs()}
             setTabs={setTabs}

--- a/playground/utils/isDarkTheme.ts
+++ b/playground/utils/isDarkTheme.ts
@@ -1,0 +1,18 @@
+export const isDarkTheme = () => {
+  if (typeof window !== 'undefined') {
+    if (window.localStorage) {
+      const isDarkTheme = window.localStorage.getItem('dark');
+      if (typeof isDarkTheme === 'string') {
+        return isDarkTheme === 'true';
+      }
+    }
+
+    const userMedia = window.matchMedia('(prefers-color-scheme: dark)');
+    if (userMedia.matches) {
+      return true;
+    }
+  }
+
+  // Default theme is light.
+  return false;
+};


### PR DESCRIPTION
Fixes: https://github.com/solidjs/solid-playground/issues/53

<details>
<summary>Page load with OS light theme</summary>

https://user-images.githubusercontent.com/16024985/129831745-6f50494d-80d8-4c1c-8ea8-b5b041d1315f.mov

</details>

<details>
<summary>Page load with OS dark theme</summary>

https://user-images.githubusercontent.com/16024985/129831707-5e3ea26b-dac1-4721-96e0-1fab182c4c0f.mov

</details>

<details>
<summary>localStorage is updated only on user interaction</summary>

https://user-images.githubusercontent.com/16024985/129831804-c4dabf15-e478-473f-9b34-1f45072d7359.mov

</details>