### PR TITLE
feat: set light color in preview in dark mode

### DIFF
--- a/src/components/preview.tsx
+++ b/src/components/preview.tsx
@@ -110,6 +110,10 @@ export const Preview: Component<Props> = (props) => {
           button:focus {
             border-color: #666;
           }
+
+          .dark {
+            color: rgba(248, 250, 252, 1)
+          }
 		    </style>
 
         <script type="module" id="setup">
@@ -160,6 +164,7 @@ export const Preview: Component<Props> = (props) => {
                 app = document.createElement('div');
                 app.id = 'app';
                 document.body.prepend(app);
+              ${props.isDark ? '  app.classList.add("dark");\n' : ''}
               }
 
               const encodedCode = encodeURIComponent(code);
@@ -263,6 +268,7 @@ export const Preview: Component<Props> = (props) => {
 type Props = JSX.HTMLAttributes<HTMLDivElement> & {
   code: string;
   reloadSignal: boolean;
+  isDark: boolean;
 };
 
 interface LogPayload {

--- a/src/components/repl.tsx
+++ b/src/components/repl.tsx
@@ -528,6 +528,7 @@ export const Repl: Component<ReplProps> = (props) => {
             class={`h-full w-full bg-white row-start-5 ${
               props.isHorizontal ? '' : 'md:row-start-2'
             }`}
+            isDark={props.dark}
           />
         </Show>
       </Suspense>


### PR DESCRIPTION
Fixes: https://github.com/solidjs/solid-playground/issues/55
However, a page reload is required for effect to be applied.

#### Screenshots:

<details>
<summary>Light mode</summary>

<img width="888" alt="light-mode" src="https://user-images.githubusercontent.com/16024985/130009911-2036c4f1-4ee8-4b2e-8e3d-2897a9a6dd99.png">


</details>

<details>
<summary>Dark mode</summary>

<img width="888" alt="dark-mode" src="https://user-images.githubusercontent.com/16024985/130009938-4bdda312-2c49-4bc5-a9f6-fbe3ec0b3f96.png">


</details>