### PR TITLE
Include ref prop on Repl Component

### DIFF
--- a/src/components/repl.tsx
+++ b/src/components/repl.tsx
@@ -41,7 +41,7 @@ export interface ReplProps {
   current: string;
   setCurrent: (tabId: string) => void;
   onEditorReady?: (editor: mEditor.IStandaloneCodeEditor) => unknown;
-  ref?: HTMLDivElement | ((el: HTMLDivElement) => void) | undefined;
+  ref?: HTMLDivElement | ((el: HTMLDivElement) => void);
 }
 
 export const Repl: Component<ReplProps> = (props) => {

--- a/src/components/repl.tsx
+++ b/src/components/repl.tsx
@@ -41,6 +41,7 @@ export interface ReplProps {
   current: string;
   setCurrent: (tabId: string) => void;
   onEditorReady?: (editor: mEditor.IStandaloneCodeEditor) => unknown;
+  ref?: HTMLDivElement | ((el: HTMLDivElement) => void) | undefined;
 }
 
 export const Repl: Component<ReplProps> = (props) => {
@@ -262,7 +263,12 @@ export const Repl: Component<ReplProps> = (props) => {
 
   return (
     <div
-      ref={(el) => setGrid(el)}
+      ref={(el) => {
+        setGrid(el);
+        if (props.ref) {
+          (props.ref as (el: HTMLDivElement) => void)(el);
+        }
+      }}
       class="relative grid bg-blueGray-50 h-full overflow-hidden text-blueGray-900 dark:text-blueGray-50 font-sans"
       classList={{
         'wrapper--forced': props.isHorizontal,

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -14,6 +14,7 @@ export declare const Repl: Component<{
   setCurrent: (x: string) => void;
   version?: string;
   onEditorReady?: (editor: mEditor.IStandaloneCodeEditor) => unknown;
+  ref?: HTMLDivElement | ((el: HTMLDivElement) => void);
 }>;
 
 export interface Tab {


### PR DESCRIPTION
Include ref prop on Repl Component.

Example:
```js
let replEl!: HTMLDivElement;

return (
    <Repl
      compiler={compiler}
      formatter={formatter}
      isHorizontal={true}
      interactive={true}
      actionBar={true}
      editableTabs={true}
      dark={false}
      //...
      ref={replEl}
    />
);
```