### PR TITLE
remove spacing around the preview iframe

### DIFF
--- a/src/components/preview.tsx
+++ b/src/components/preview.tsx
@@ -203,7 +203,7 @@ export const Preview: Component<Props> = (props) => {
     >
       <iframe
         title="Solid REPL"
-        class="overflow-auto p-2 w-full h-full dark:bg-other"
+        class="overflow-auto p-0 w-full h-full dark:bg-other block"
         ref={iframe}
         // @ts-ignore
         sandbox="allow-popups-to-escape-sandbox allow-scripts allow-popups allow-forms allow-pointer-lock allow-top-navigation allow-modals allow-same-origin"


### PR DESCRIPTION
This is so that examples can use the whole iframe. Otherwise, if a playground has code like

```js
document.querySelector('head').innerHTML += `<style>
  html, body, #app {
    width: 100%;
    height: 100%;
    padding: 0;
  }
</style>`;
```

then an amount of content (equal to the padding) will stick beyond the bottom edge of the preview. The `block` display prevents vertical displacement due to some font configurations for inline-block elements, and we're not rendering the canvas within text.