### PR TITLE
fix styling

### DIFF
--- a/playground/components/header.tsx
+++ b/playground/components/header.tsx
@@ -71,7 +71,7 @@ export const Header: Component<{
       </h1>
       <div class="flex items-center space-x-2">
         <Dismiss
-          classList={{ 'absolute top-[53px] right-[10px] w-[fit-content]': showMenu() }}
+          classList={{ 'absolute top-[53px] right-[10px] w-[fit-content] z-10': showMenu() }}
           menuButton={() => menuBtnEl}
           open={showMenu}
           setOpen={setShowMenu}

--- a/playground/components/zoomDropdown.tsx
+++ b/playground/components/zoomDropdown.tsx
@@ -102,7 +102,7 @@ export const ZoomDropdown: Component<{ showMenu: boolean }> = (props) => {
       </button>
       <Dismiss menuButton={btnEl} open={open} setOpen={setOpen}>
         <div
-          class="absolute top-full left-1/2 bg-white dark:bg-gray-700 text-brand-default border border-gray-900 rounded shadow  p-6 -translate-x-1/2 z-10"
+          class="fixed right-0 top-[48px] bg-white dark:bg-gray-700 text-brand-default border border-gray-900 rounded shadow p-6 w-min z-10"
           classList={{
             'left-1/4': props.showMenu,
           }}


### PR DESCRIPTION
Dropdown navigation menu on mobile is overlapped and can't be interacted.
![2022-01-13_14-57](https://user-images.githubusercontent.com/29286430/149422505-f7928a14-d6eb-468e-96da-a5e5947b476d.png)


Page zoom dropdown is partially cutoff.

![2022-01-13_14-57_1](https://user-images.githubusercontent.com/29286430/149422543-5ebba7ae-38e9-41f6-bc40-76958fa82e7f.png)


Fixes these two styling issues