### PR TITLE
feat: add format icon to header

### DIFF
--- a/playground/app.tsx
+++ b/playground/app.tsx
@@ -4,6 +4,7 @@ import { Show, onCleanup, createEffect, createSignal, JSX } from 'solid-js';
 import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker';
 import tsWorker from 'monaco-editor/esm/vs/language/typescript/ts.worker?worker';
 import cssWorker from 'monaco-editor/esm/vs/language/css/css.worker?worker';
+import type { editor as mEditor } from 'monaco-editor';
 
 import pkg from '../package.json';
 import { eventBus } from './utils/eventBus';
@@ -56,6 +57,9 @@ export const App = (): JSX.Element => {
 
   const params = Object.fromEntries(url.searchParams.entries());
   const [version, setVersion] = createSignal(params.version || pkg.dependencies['solid-js']);
+
+  const [format, setFormat] = createSignal(false);
+  let editor: mEditor.IStandaloneCodeEditor | undefined;
 
   /**
    * This syncs the URL hash with the state of the current tab.
@@ -127,6 +131,14 @@ export const App = (): JSX.Element => {
               setDark(toggledValue);
               localStorage.setItem('dark', String(toggledValue));
             }}
+            formatCode={() => {
+              if (!format()) {
+                editor?.getAction('editor.action.formatDocument').run();
+                editor?.focus();
+              }
+              setFormat(true);
+              setTimeout(setFormat, 750, false);
+            }}
             isHorizontal={isHorizontal}
             tabs={tabs()}
             setTabs={setTabs}
@@ -151,6 +163,9 @@ export const App = (): JSX.Element => {
         setCurrent={setCurrent}
         version={version()}
         id="repl"
+        onEditorReady={(_editor) => {
+          editor = _editor;
+        }}
       />
 
       <Show when={newUpdate()} children={<Update onDismiss={() => setNewUpdate(false)} />} />

--- a/playground/components/header.tsx
+++ b/playground/components/header.tsx
@@ -14,6 +14,7 @@ const SOLID_VERSION = pkg.dependencies['solid-js'];
 export const Header: Component<{
   dark: boolean;
   toggleDark: () => void;
+  formatCode: () => void;
   isHorizontal: boolean;
   tabs: Tab[];
   setTabs: (tabs: Tab[]) => void;
@@ -84,6 +85,33 @@ export const Header: Component<{
               hidden: !showMenu(),
             }}
           >
+            <button
+              type="button"
+              onClick={props.formatCode}
+              class="md:text-white flex flex-row space-x-2 items-center md:px-3 px-2 py-2 focus:outline-none focus:ring-1 rounded opacity-80 hover:opacity-100"
+              classList={{
+                'rounded-none	active:bg-gray-300 hover:bg-gray-300 dark:hover:text-black focus:outline-none focus:highlight-none active:highlight-none focus:ring-0 active:outline-none':
+                  showMenu(),
+              }}
+              title="Format current document"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                class="h-6 w-6"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M4 6h16M4 12h16M4 18h7"
+                />
+              </svg>
+              <span class="text-xs md:sr-only">Format current document</span>
+            </button>
+
             <button
               type="button"
               onClick={props.toggleDark}


### PR DESCRIPTION
This adds an icon to the header that formats the current active document/tab on click.

<img width="447" alt="Formatting icon" src="https://user-images.githubusercontent.com/6840287/153408904-95db1b99-abe7-42c0-acf4-a657b0a02178.png">
