### PR TITLE
:sparkles: Add export as json format

### DIFF
--- a/playground/app.tsx
+++ b/playground/app.tsx
@@ -18,6 +18,7 @@ import CompilerWorker from '../src/workers/compiler?worker';
 import FormatterWorker from '../src/workers/formatter?worker';
 import useZoom from '../src/hooks/useZoom';
 import { isDarkTheme } from './utils/isDarkTheme';
+import { exportToJSON } from './utils/exportFiles';
 
 (window as any).MonacoEnvironment = {
   getWorker(_moduleId: unknown, label: string) {
@@ -87,6 +88,10 @@ export const App = (): JSX.Element => {
     'isHorizontal',
     'noEditableTabs',
   ].map((key) => key in params);
+
+  if (params.format === 'json') {
+    exportToJSON(tabs());
+  }
 
   const [dark, setDark] = createSignal(isDarkTheme());
 

--- a/playground/utils/exportFiles.tsx
+++ b/playground/utils/exportFiles.tsx
@@ -152,3 +152,22 @@ export async function exportToZip(tabs: Tab[]): Promise<void> {
   anchor.click();
   anchor.remove();
 }
+
+/**
+ * This function will convert the tabs of the playground
+ * into a JSON formatted playground that can then be reimported later on
+ * via the url `https://playground.solidjs.com/?data=my-file.json` or
+ * vua the import button
+ *
+ * @param tabs {Tab[]} - The tabs to export
+ */
+export function exportToJSON(tabs: Tab[]): void {
+  const files = tabs.map<{ name: string; content: string }>((tab) => ({
+    name: tab.name,
+    type: tab.type,
+    content: tab.source,
+  }));
+
+  const blob = new Blob([JSON.stringify({ files }, null, 4)], { type: 'application/json' });
+  location.href = URL.createObjectURL(blob);
+}


### PR DESCRIPTION
Added a way to specify `?format=json` so that users feeding content for the playground as a component can easily export / import existing playgrounds into examples (especially @davedbase on the website).

@modderme123 If you don't mind checking it out before I merge, that'd be awesome!