### PR TITLE
Typofix with corsHeaders in workers-site/index.js

### DIFF
--- a/workers-site/index.js
+++ b/workers-site/index.js
@@ -80,7 +80,7 @@ async function handleCreateUrl(request) {
 
   // And return it with proper headers
   const response = new Response(id, { status: 200 });
-  response.headers.set('Access-Control-Allow-Origin', corsHeaders['ccess-Control-Allow-Origin']);
+  response.headers.set('Access-Control-Allow-Origin', corsHeaders['Access-Control-Allow-Origin']);
   response.headers.append('Vary', 'Origin');
 
   return response;


### PR DESCRIPTION
Fixed a super minuscule typo in workers-site/index.js that was causing the `Access-Control-Allow-Origin` header to not be applied.

119894125696fa4dac85bc861936ade58d7f25a6