### PR TITLE
fix fake console throwing and unintentional tracking

### DIFF
--- a/src/workers/compiler.ts
+++ b/src/workers/compiler.ts
@@ -124,6 +124,9 @@ function virtual({
       // Compile solid code
       if (/\.(j|t)sx$/.test(filename)) {
         const babel = await loadBabel(solidVersion);
+        // HACK: Import untrack from the same solid-js version; used when logging to fake console
+        code =
+          ';import { untrack as $$untrack } from "solid-js";window.$$untrack = $$untrack;' + code;
 
         return babel(code, { solid: solidOptions, babel: { filename } });
       }

--- a/src/workers/compiler.ts
+++ b/src/workers/compiler.ts
@@ -126,7 +126,7 @@ function virtual({
         const babel = await loadBabel(solidVersion);
         // HACK: Import untrack from the same solid-js version; used when logging to fake console
         code =
-          ';import { untrack as $$untrack } from "solid-js";window.$$untrack = $$untrack;' + code;
+          'import { untrack as $$untrack } from "solid-js";window.$$untrack = $$untrack;' + code;
 
         return babel(code, { solid: solidOptions, babel: { filename } });
       }


### PR DESCRIPTION
- Stop throwing when BigInts and circular references passed to `JSON.stringify`
- Untrack formatArgs to stop property accesses causing effects to rerun

Fixes #99 

This solution is a little hacky, though. 