### PR TITLE
Change default TypeScript behavior to strict: true (fix #41)

### DIFF
--- a/playground/utils/exportFiles.tsx
+++ b/playground/utils/exportFiles.tsx
@@ -19,7 +19,7 @@ export default defineConfig({
 const tsConfig = JSON.stringify(
   {
     compilerOptions: {
-      strict: false,
+      strict: true,
       module: 'ESNext',
       target: 'ESNext',
       jsx: 'preserve',

--- a/src/components/editor/setupSolid.ts
+++ b/src/components/editor/setupSolid.ts
@@ -65,6 +65,7 @@ cm(sStore, 'store/types/store.d.ts');
 languages.typescript.typescriptDefaults.setEagerModelSync(true);
 
 languages.typescript.typescriptDefaults.setCompilerOptions({
+  strict: true,
   target: languages.typescript.ScriptTarget.ESNext,
   module: languages.typescript.ModuleKind.ESNext,
   moduleResolution: languages.typescript.ModuleResolutionKind.NodeJs,


### PR DESCRIPTION
This PR enables `strict: true` diagnostic errors from TypeScript (only when the "Display Errors" checkbox is checked), as requested in #41.  Example:

![image](https://user-images.githubusercontent.com/2218736/167315373-182f81bd-db61-400b-b609-0cc32cdf350f.png)

But I'm having some trouble with this turned on and the variable actually gets used (so it doesn't get tree shaken away).  It seems that TypeScript is somehow processing the same file twice, which leads to new errors:

![image](https://user-images.githubusercontent.com/2218736/167315435-0e5c6d60-bbe9-4008-b748-d48da4348fb4.png)

It seems that `src/components/editor/monacoTabs.tsx`'s `MonacoTabs` creates two models: the `model` at the top of the function and the `model` for each `tab` in `tabs`.  I'm seeing the same source code in both the root model and a tab, which is presumably the source of the problem.  Why this isn't a problem without `strict` mode, I'm not sure.  @amoutonbrady Could you explain what's going on here?  Could we remove one of the duplicates (presumably the top-level `model`?)?