### PR TITLE
Support import from URL without CDN

### DIFF
--- a/src/workers/compiler.ts
+++ b/src/workers/compiler.ts
@@ -66,10 +66,10 @@ function generateCodeString(tab: Tab) {
 
 /**
  * This is a custom rollup plugin to handle tabs as a
- * virtual file system and replacing every imports with a
+ * virtual file system and replacing every non-URL import with an
  * ESM CDN import.
  *
- * Note: Passing in the Solid Version for letter use
+ * Note: Passing in the Solid Version for later use
  */
 function virtual({
   solidVersion,
@@ -86,7 +86,15 @@ function virtual({
       // This is a tab being imported
       if (importee.startsWith('.')) return importee.replace('.tsx', '') + '.tsx';
 
-      // This is an external module
+      // External URL
+      if (importee.includes('://')) {
+        return {
+          id: importee,
+          external: true
+        };
+      }
+
+      // NPM module via ESM CDN
       return {
         id: `${CDN_URL}/${importee.replace('solid-js', `solid-js@${solidVersion}`)}`,
         external: true,


### PR DESCRIPTION
On Discord, liquid reported that `import`s from URLs don't work: the Playground tries to prepend the ESM CDN even when an explicit URL is given.  This small PR stops that behavior, using the given URL if it's a URL (contains `://`). Example:

![image](https://user-images.githubusercontent.com/2218736/169608051-bef0f45f-d4f5-4c1b-aa65-c7f490349406.png)

It doesn't play well with TypeScript, but that's a regular TypeScript issue. [Relevant StackOverflow post](https://stackoverflow.com/questions/62124572/import-es6-module-from-http-url-in-typescript). We can silence the error but I imagine it's tricky to get the type definitions actually used. Still, better than not working at all.