### PR TITLE
Mini-PR-to-name-downloaded-zip-folders

### DIFF
--- a/playground/utils/exportFiles.tsx
+++ b/playground/utils/exportFiles.tsx
@@ -88,7 +88,7 @@ export async function exportToZip(tabs: Tab[]): Promise<void> {
   const blob = await zip.generateAsync({ type: 'blob' });
   const url = URL.createObjectURL(blob);
 
-  const anchor = (<a href={url} target="_blank" rel="noopener" download />) as HTMLElement;
+  const anchor = (<a href={url} target="_blank" rel="noopener" download="solid-playground-poject" />) as HTMLElement;
   document.body.prepend(anchor);
   anchor.click();
   anchor.remove();


### PR DESCRIPTION
By adding a value to the `download` attribute, we can give a name to the downloaded `.zip` folder, instead of the combination of numbers and characters that we currently get (e.g. `f4c7rz45c14r1x.zip`).