### PR TITLE
Add ESLint support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ lib
 .yarn*
 yarn.lock
 package-lock.json
+
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@solid-primitives/scheduled": "^1.0.0",
     "babel-preset-solid": "1.4.8",
     "dedent": "^0.7.0",
+    "eslint-solid-standalone": "^0.1.5",
     "jszip": "^3.10.1",
     "monaco-editor-textmate": "^3.0.0",
     "monaco-textmate": "^3.0.1",

--- a/playground/pages/edit.tsx
+++ b/playground/pages/edit.tsx
@@ -3,6 +3,7 @@ import tsWorker from 'monaco-editor/esm/vs/language/typescript/ts.worker?worker'
 import cssWorker from 'monaco-editor/esm/vs/language/css/css.worker?worker';
 import CompilerWorker from '../../src/workers/compiler?worker';
 import FormatterWorker from '../../src/workers/formatter?worker';
+import LinterWorker from '../../src/workers/linter?worker';
 import onigasm from 'onigasm/lib/onigasm.wasm?url';
 import { batch, createResource, createSignal, lazy, onCleanup, Show, Suspense } from 'solid-js';
 import { useMatch, useNavigate, useParams } from '@solidjs/router';
@@ -39,6 +40,7 @@ export const Edit = (props: { horizontal: boolean }) => {
   const scratchpad = useMatch(() => '/scratchpad');
   const compiler = new CompilerWorker();
   const formatter = new FormatterWorker();
+  const linter = new LinterWorker();
 
   const params = useParams();
   const context = useAppContext()!;
@@ -214,6 +216,7 @@ export const Edit = (props: { horizontal: boolean }) => {
           <Repl
             compiler={compiler}
             formatter={formatter}
+            linter={linter}
             isHorizontal={props.horizontal}
             dark={context.dark()}
             tabs={tabs()}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,7 @@ specifiers:
   assert: ^2.0.0
   babel-preset-solid: 1.4.8
   dedent: ^0.7.0
+  eslint-solid-standalone: ^0.1.5
   fs-extra: ^10.1.0
   jiti: ^1.14.0
   jszip: ^3.10.1
@@ -60,6 +61,7 @@ dependencies:
   '@solid-primitives/scheduled': 1.0.0_solid-js@1.4.8
   babel-preset-solid: 1.4.8_@babel+core@7.18.13
   dedent: 0.7.0
+  eslint-solid-standalone: 0.1.5_typescript@4.7.4
   jszip: 3.10.1
   monaco-editor-textmate: 3.0.0_ss6lrp45w75rkjvqfs3bsfnncy
   monaco-textmate: 3.0.1_onigasm@2.2.5
@@ -67,7 +69,7 @@ dependencies:
   prettier: 2.7.1
   rollup: 2.78.1
   solid-dismiss: 1.2.1_solid-js@1.4.8
-  solid-heroicons: 2.0.3
+  solid-heroicons: 2.0.3_solid-js@1.4.8
   solid-js: 1.4.8
 
 devDependencies:
@@ -1564,13 +1566,19 @@ packages:
     resolution: {integrity: sha512-EGlKlgMhnLt/cM4DbUSafFdrkeJoC9Mvnj0PUCU7tFmTjMjNRT957kXCx0wYm3JuEq4o4ZsS5vG+NlkM2DMd2A==}
     dev: true
 
+  /@types/eslint/8.4.6:
+    resolution: {integrity: sha512-/fqTbjxyFUaYNO7VcW5g+4npmqVACz1bB7RTHYuLj+PRjw9hrCwrUXVQFpChUS0JsyEFvMZ7U/PfmvWgxJhI9g==}
+    dependencies:
+      '@types/estree': 1.0.0
+      '@types/json-schema': 7.0.11
+    dev: false
+
   /@types/estree/0.0.39:
     resolution: {integrity: sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==}
     dev: true
 
   /@types/estree/1.0.0:
     resolution: {integrity: sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==}
-    dev: true
 
   /@types/fs-extra/9.0.13:
     resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
@@ -1584,6 +1592,10 @@ packages:
       '@types/minimatch': 3.0.5
       '@types/node': 18.7.10
     dev: true
+
+  /@types/json-schema/7.0.11:
+    resolution: {integrity: sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==}
+    dev: false
 
   /@types/keyv/3.1.4:
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
@@ -2548,6 +2560,15 @@ packages:
   /escape-string-regexp/1.0.5:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
     engines: {node: '>=0.8.0'}
+
+  /eslint-solid-standalone/0.1.5_typescript@4.7.4:
+    resolution: {integrity: sha512-fa/xkbVgeqhhJKCsl6oe3321/+YytjX5Kal8RBR++iXkKn5m4FEXzf+Ed4XtIT36zHLCAm4lhIEVderbspLgtw==}
+    peerDependencies:
+      typescript: ^4.0.0
+    dependencies:
+      '@types/eslint': 8.4.6
+      typescript: 4.7.4
+    dev: false
 
   /estree-walker/1.0.1:
     resolution: {integrity: sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==}
@@ -4040,8 +4061,10 @@ packages:
       solid-js: 1.4.8
     dev: false
 
-  /solid-heroicons/2.0.3:
+  /solid-heroicons/2.0.3_solid-js@1.4.8:
     resolution: {integrity: sha512-sHlEaCaFFD8s/RDWTlmfIC/5dUPOtRB/UqOTpXQLq/BUZ94jWS58CANwONBclxwKFFGu6iasaP5zN4iYqORlVg==}
+    peerDependencies:
+      solid-js: '>= ^1.2.5'
     dependencies:
       solid-js: 1.4.8
     dev: false
@@ -4323,7 +4346,6 @@ packages:
     resolution: {integrity: sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==}
     engines: {node: '>=4.2.0'}
     hasBin: true
-    dev: true
 
   /unbox-primitive/1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -110,7 +110,13 @@ const preppy = {
 };
 
 rollup({
-  input: ['src/index.ts', 'src/workers/compiler.ts', 'src/workers/formatter.ts', 'src/components/repl.tsx'],
+  input: [
+    'src/index.ts',
+    'src/workers/compiler.ts',
+    'src/workers/formatter.ts',
+    'src/workers/linter.ts',
+    'src/components/repl.tsx',
+  ],
   external: ['solid-js', 'solid-js/web', 'solid-js/store', 'monaco-editor'],
   acornInjectPlugins: [jsx()],
   plugins: [

--- a/src/components/editor/index.tsx
+++ b/src/components/editor/index.tsx
@@ -152,21 +152,16 @@ const Editor: Component<{
     });
   });
 
-  createEffect(
-    on(
-      () => props.displayLintMessages,
-      () => {
-        if (props.displayLintMessages) {
-          // run on mount and when displayLintMessages is turned on
-          runLinter(editor.getValue());
-        } else {
-          // reset eslint markers when displayLintMessages is turned off
-          const m = model();
-          m && mEditor.setModelMarkers(m, 'eslint', []);
-        }
-      },
-    ),
-  );
+  createEffect(() => {
+    if (props.displayLintMessages) {
+      // run on mount and when displayLintMessages is turned on
+      runLinter(editor.getValue());
+    } else {
+      // reset eslint markers when displayLintMessages is turned off
+      const m = model();
+      m && mEditor.setModelMarkers(m, 'eslint', []);
+    }
+  });
 
   onMount(() => {
     props.onEditorReady?.(editor, { Uri, editor: mEditor });

--- a/src/components/repl.tsx
+++ b/src/components/repl.tsx
@@ -22,7 +22,7 @@ const compileMode = {
 } as const;
 
 const Repl: ReplProps = (props) => {
-  const { compiler, formatter } = props;
+  const { compiler, formatter, linter } = props;
   let now: number;
 
   const tabRefs = new Map<string, HTMLSpanElement>();
@@ -166,6 +166,7 @@ const Repl: ReplProps = (props) => {
   const [reloadSignal, reload] = createSignal(false, { equals: false });
   const [devtoolsOpen, setDevtoolsOpen] = createSignal(true);
   const [displayErrors, setDisplayErrors] = createSignal(true);
+  const [displayLintMessages, setDisplayLintMessages] = createSignal(true);
 
   return (
     <div
@@ -251,6 +252,17 @@ const Repl: ReplProps = (props) => {
               <span>Display Errors</span>
             </label>
           </TabItem>
+          <TabItem class="justify-self-end">
+            <label class="space-x-2 px-3 py-2 cursor-pointer">
+              <input
+                type="checkbox"
+                name="run-linter"
+                checked={displayLintMessages()}
+                onChange={(event) => setDisplayLintMessages(event.currentTarget.checked)}
+              />
+              <span>Run Linter</span>
+            </label>
+          </TabItem>
         </TabList>
 
         <MonacoTabs tabs={props.tabs} folder={props.id} />
@@ -260,10 +272,12 @@ const Repl: ReplProps = (props) => {
             url={`file:///${props.id}/${props.current}`}
             onDocChange={() => compile()}
             formatter={formatter}
+            linter={linter}
             isDark={props.dark}
             withMinimap={false}
             onEditorReady={props.onEditorReady}
             displayErrors={displayErrors()}
+            displayLintMessages={displayLintMessages()}
           />
         </Show>
 

--- a/src/workers/compiler.ts
+++ b/src/workers/compiler.ts
@@ -123,7 +123,7 @@ self.addEventListener('message', async ({ data }) => {
   try {
     if (event === 'BABEL') {
       self.postMessage(await babel(tab, compileOpts));
-    } else {
+    } else if (event === 'ROLLUP') {
       self.postMessage(await compile(tabs, event));
     }
   } catch (e) {

--- a/src/workers/linter.ts
+++ b/src/workers/linter.ts
@@ -1,0 +1,56 @@
+import { verify, verifyAndFix, pluginVersion, eslintVersion, plugin } from 'eslint-solid-standalone';
+import type { Linter } from 'eslint-solid-standalone';
+import type { Tab } from 'solid-repl';
+
+type RuleSeverityOverrides = Parameters<typeof verify>[1];
+interface Payload {
+  data:
+    | {
+        event: 'LINT' | 'FIX';
+        tab: Tab;
+        ruleSeverityOverrides?: RuleSeverityOverrides;
+      }
+    | {
+        event: 'META';
+      };
+}
+
+self.addEventListener('message', async ({ data }: Payload) => {
+  const { event } = data;
+  try {
+    if (event === 'LINT') {
+      const { tab, ruleSeverityOverrides } = data;
+      self.postMessage({
+        event: 'LINT',
+        lintMessages: await verify(tab.source, ruleSeverityOverrides),
+      });
+    } else if (event === 'FIX') {
+      const { tab, ruleSeverityOverrides } = data;
+      self.postMessage({
+        event: 'FIX',
+        fixReport: await verifyAndFix(tab.source, ruleSeverityOverrides),
+      });
+    } else if (event === 'META') {
+      self.postMessage({
+        event: 'META',
+        pluginVersion,
+        eslintVersion,
+        // send the prebuilt configs as maps of rule names to 0 | 1 | 2
+        // map over objects to simplify any complex options, eslint-solid-standalone only accepts
+        // severity changes
+        configs: Object.keys(plugin.configs!).reduce((configs, key) => {
+          configs[key] = Object.keys(plugin.configs![key]).reduce((config, rule) => {
+            const ruleConfig = plugin.configs![key].rules![rule];
+            config[rule] = Array.isArray(ruleConfig)
+              ? (ruleConfig[0] as Linter.Severity)
+              : (ruleConfig as Linter.Severity);
+            return config;
+          }, {} as Record<string, Linter.Severity>);
+          return configs;
+        }, {} as Record<string, Record<string, Linter.Severity>>),
+      });
+    }
+  } catch (e) {
+    self.postMessage({ event: 'ERROR', error: (e as Error).message });
+  }
+});

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -10,7 +10,8 @@ declare module 'solid-repl' {
 declare module 'solid-repl/lib/repl' {
   export type Repl = import('solid-js').Component<{
     compiler: Worker;
-    formatter?: Worker;
+    formatter: Worker;
+    linter: Worker;
     isHorizontal: boolean;
     dark: boolean;
     tabs: Tab[];


### PR DESCRIPTION
Closes #111. Finally got this working nicely on my local machine!

ESLint warnings and errors now show up in the editor like they normally do in a VSCode environment, using a web worker so as not to block the main thread. There's a new checkbox next to "Display Errors" titled "Run Linter" that turns linting on and off. Turning it off skips running ESLint so there's no wasted compute. I've implemented auto-fixing on `cmd+s` and added an auto-fix action to the context menu. That's all for new features, I tried to keep the scope fairly small.

This is implemented using my package [`eslint-solid-standalone`](https://github.com/joshwilsonvu/eslint-plugin-solid/blob/main/standalone/README.md), which handles bundling ESLint and `eslint-plugin-solid` together while stripping out web-incompatible code. I'll release a new version whenever I release `eslint-plugin-solid`. We could support changing the ESLint config to some degree (which rules are on/off), but I felt that was more of a UI/UX challenge than a technical one and left it as simply Run or Don't Run for now.

I'd love if you all gave this a try and let me know if I can make any changes to help it land. Thanks!