### PR TITLE
fix exportToZip

### DIFF
--- a/playground/utils/exportFiles.tsx
+++ b/playground/utils/exportFiles.tsx
@@ -150,8 +150,10 @@ export async function exportToZip(tabs: Tab[], imports: string[]): Promise<void>
   zip.file('package.json', await packageJSON(imports));
   zip.file('vite.config.ts', viteConfigFile);
   zip.file('tsconfig.json', tsConfig);
+  zip.folder("src");
+
   for (const tab of tabs) {
-    zip.file(tab.name, tab.source);
+    zip.file(`src/${tab.name}`, tab.source);
   }
 
   const blob = await zip.generateAsync({ type: 'blob' });

--- a/playground/utils/exportFiles.tsx
+++ b/playground/utils/exportFiles.tsx
@@ -51,7 +51,7 @@ const indexHTML = (tabs: Tab[]) => dedent`
   <body>
     <div id="app"></div>
 
-    <script type="module" src="./src/${tabs[0].name}.tsx"></script>
+    <script type="module" src="./src/${tabs[0].name}"></script>
   </body>
 </html>
 `;


### PR DESCRIPTION
`exportToZip` had bugs regarding the `script`-tag of `indexHTML`
the script-tag would look like `<script type="module" src="./src/main.tsx.tsx"></script>`
whereas all the files were located in the root-directory (and the double .tsx-extension).

I added code so JSZip would create a directory called `./src` and the files would be added to this directory, as was the case in earlier versions, and removed the `.tsx` from `indexHTML` as the name of a tab contains the extension.
