### PR TITLE
Set chrome devtools console-tab as default instead of elements tab

### DIFF
--- a/src/components/preview.tsx
+++ b/src/components/preview.tsx
@@ -10,10 +10,12 @@ export const Preview: Component<Props> = (props) => {
   const [isIframeReady, setIframeReady] = createSignal(false);
 
   if (!isServer) {
-    const selectedPanel = localStorage.getItem('panel-selectedTab');
-    if (!selectedPanel) {
-      localStorage.setItem('panel-selectedTab', '"console"');
-    }
+    try {
+      const selectedPanel = localStorage.getItem('panel-selectedTab');
+      if (!selectedPanel) {
+        localStorage.setItem('panel-selectedTab', '"console"');
+      }
+    } catch (err) {}
   }
 
   createEffect(() => {

--- a/src/components/preview.tsx
+++ b/src/components/preview.tsx
@@ -1,4 +1,5 @@
 import { Component, createEffect, createSignal, onCleanup } from 'solid-js';
+import { isServer } from 'solid-js/web';
 import { useZoom } from '../hooks/useZoom';
 
 export const Preview: Component<Props> = (props) => {
@@ -7,6 +8,13 @@ export const Preview: Component<Props> = (props) => {
   let iframe!: HTMLIFrameElement;
 
   const [isIframeReady, setIframeReady] = createSignal(false);
+
+  if (!isServer) {
+    const selectedPanel = localStorage.getItem('panel-selectedTab');
+    if (!selectedPanel) {
+      localStorage.setItem('panel-selectedTab', '"console"');
+    }
+  }
 
   createEffect(() => {
     if (!props.code) return;


### PR DESCRIPTION
Set chrome devtools console-tab as default instead of elements tab on fresh session.

Why? To have consistency, on other browsers when [eruda devtools](https://github.com/liriliri/eruda) is initialized, it's default tab is console tab.

