### PR TITLE
Bump eslint-solid-standalone to fix broken linting.

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@unocss/reset": "^0.45.29",
     "babel-preset-solid": "1.5.7",
     "dedent": "^0.7.0",
-    "eslint-solid-standalone": "^0.1.5",
+    "eslint-solid-standalone": "^0.9.3",
     "jszip": "^3.10.1",
     "monaco-editor-textmate": "^4.0.0",
     "monaco-textmate": "^3.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,7 +30,7 @@ specifiers:
   assert: ^2.0.0
   babel-preset-solid: 1.5.7
   dedent: ^0.7.0
-  eslint-solid-standalone: ^0.1.5
+  eslint-solid-standalone: ^0.9.3
   fs-extra: ^10.1.0
   jiti: ^1.16.0
   jszip: ^3.10.1
@@ -63,7 +63,7 @@ dependencies:
   '@unocss/reset': 0.45.29
   babel-preset-solid: 1.5.7_@babel+core@7.19.3
   dedent: 0.7.0
-  eslint-solid-standalone: 0.1.5_typescript@4.8.4
+  eslint-solid-standalone: 0.9.3_typescript@4.8.4
   jszip: 3.10.1
   monaco-editor-textmate: 4.0.0_ss6lrp45w75rkjvqfs3bsfnncy
   monaco-textmate: 3.0.1_onigasm@2.2.5
@@ -656,8 +656,8 @@ packages:
     resolution: {integrity: sha512-EGlKlgMhnLt/cM4DbUSafFdrkeJoC9Mvnj0PUCU7tFmTjMjNRT957kXCx0wYm3JuEq4o4ZsS5vG+NlkM2DMd2A==}
     dev: true
 
-  /@types/eslint/8.4.6:
-    resolution: {integrity: sha512-/fqTbjxyFUaYNO7VcW5g+4npmqVACz1bB7RTHYuLj+PRjw9hrCwrUXVQFpChUS0JsyEFvMZ7U/PfmvWgxJhI9g==}
+  /@types/eslint/8.4.10:
+    resolution: {integrity: sha512-Sl/HOqN8NKPmhWo2VBEPm0nvHnu2LL3v9vKo8MEq0EtbJ4eVzGPl41VNPvn5E1i5poMk4/XD8UriLHpJvEP/Nw==}
     dependencies:
       '@types/estree': 1.0.0
       '@types/json-schema': 7.0.11
@@ -1384,12 +1384,12 @@ packages:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
     engines: {node: '>=0.8.0'}
 
-  /eslint-solid-standalone/0.1.5_typescript@4.8.4:
-    resolution: {integrity: sha512-fa/xkbVgeqhhJKCsl6oe3321/+YytjX5Kal8RBR++iXkKn5m4FEXzf+Ed4XtIT36zHLCAm4lhIEVderbspLgtw==}
+  /eslint-solid-standalone/0.9.3_typescript@4.8.4:
+    resolution: {integrity: sha512-VzzakDhrJrqt1dFi+JLVUqs8UIKUOeY14EBP75PiYmTZ2caagGMCnKkMDNLzKD5h3GI8PA7UquUdMQCGzEAeeQ==}
     peerDependencies:
       typescript: ^4.0.0
     dependencies:
-      '@types/eslint': 8.4.6
+      '@types/eslint': 8.4.10
       typescript: 4.8.4
     dev: false
 


### PR DESCRIPTION
Thanks for merging #120 a few months back! Because of some UI cleanup it wasn't immediately apparent to me that you had deployed that code to `playground.solidjs.com`, but I recently noticed that you did and that the linting wasn't working correctly (at least in the production build).

I'm not sure exactly when it happened, but at some point the `eslint-solid-standalone` package that powers linting for the playground started referencing `process.env.*` and erroring out. I traced it back to an issue with its build process and addressed it [here](https://github.com/solidjs-community/eslint-plugin-solid/pull/65).

This PR is just the result of running `pnpm up --latest eslint-solid-standalone`—linting should start working again as soon as this is merged and deployed.

I'm wondering if it might be worth it to specify `"eslint-solid-standalone": "latest"` in your `package.json` so that we don't have to worry about manual upgrade PRs when new versions come out? Up to you.