### PR TITLE
Reset Editor button now has a title attribute, check for chromium improved

### DIFF
--- a/src/components/preview.tsx
+++ b/src/components/preview.tsx
@@ -44,10 +44,8 @@ export const Preview: Component<Props> = (props) => {
     iframe.contentWindow!.postMessage({ event: 'THEME', value: props.isDark }, '*');
   });
 
-  const ua = navigator.userAgent.toLowerCase();
-  const isChrome = /(?!chrom.*opr)chrom(?:e|ium)\/([0-9.]+)(:?\s|$)/.test(ua);
-
-  const devtools = isChrome
+  const isChromium = (window as any).chrome !== undefined;
+  const devtools = isChromium
     ? `<script src="https://cdn.jsdelivr.net/npm/chii@1.2.0/public/target.js" embedded="true" cdn="https://cdn.jsdelivr.net/npm/chii@1.2.0/public"></script>
       <script>
         let bodyHeight;

--- a/src/components/repl.tsx
+++ b/src/components/repl.tsx
@@ -248,7 +248,7 @@ const Repl: ReplProps = (props) => {
             </button>
           </li>
           <TabItem class="ml-auto justify-self-end">
-            <button class="cursor-pointer space-x-2 px-2 py-2" onclick={resetTabs}>
+            <button class="cursor-pointer space-x-2 px-2 py-2" onclick={resetTabs} title="Reset Editor">
               <Icon path={trash} class="h-5" />
               <span class="sr-only">Reset Editor</span>
             </button>


### PR DESCRIPTION
Added title attribute to Reset Editor button
The check for chromium now checks if window.chrome is defined, which means that more chromium based browsers, such as opera are detected. This resolves #132 