### PR TITLE
Add role="button" and tabindex="0" to file tabs

### DIFF
--- a/src/components/repl.tsx
+++ b/src/components/repl.tsx
@@ -257,6 +257,7 @@ export const Repl: ReplProps = (props) => {
                     tabRefs.get(tab.name)?.focus();
                   }}
                   title={tab.name}
+                  role="button"
                 >
                   {tab.name}
                 </div>
@@ -284,6 +285,7 @@ export const Repl: ReplProps = (props) => {
               class="cursor-pointer space-x-2 px-3 py-2"
               onclick={() => props.setCurrent('import_map.json')}
               title="Import Map"
+              role="button"
             >
               <Icon path={inboxStack} class="h-5" />
               <span class="sr-only">Import Map</span>


### PR DESCRIPTION
Adding role="button" to file tabs allows accessibility tools to recognise them as clickable. For example, when using the Chrome plugin "Vimium", you can press the `F` key to see all clickable elements. With this change, the file tabs become interactable.

Adding tabindex="0" allows file tabs to be focused when tabbing through the page using a keyboard. I had to make some modifications to the code related to renaming tabs to get tabbing to work properly.