### PR TITLE
small improvement to default example

### DIFF
--- a/packages/solid-repl/src/index.ts
+++ b/packages/solid-repl/src/index.ts
@@ -5,7 +5,7 @@ import { createSignal } from "solid-js";
 
 function Counter() {
   const [count, setCount] = createSignal(1);
-  const increment = () => setCount(count() + 1);
+  const increment = () => setCount(count => count + 1);
 
   return (
     <button type="button" onClick={increment}>


### PR DESCRIPTION
The default example includes `setCount(count()+1)` Probably unharmful, but a bad practice, because `count()` will cause tracking, for the sake of education I believe `setCount(count => count+1)` would be better