### PR TITLE
Fix broken zooming devtools and other styling issues

### DIFF
--- a/packages/playground/index.html
+++ b/packages/playground/index.html
@@ -10,7 +10,7 @@
   </head>
   <body>
     <div id="app"></div>
-    <div id="update" class="fixed bottom-10 left-10"></div>
+    <div id="update" class="z-12 fixed bottom-10 left-10"></div>
     <script src="./src/index.tsx" type="module"></script>
   </body>
 </html>

--- a/packages/playground/src/components/header.tsx
+++ b/packages/playground/src/components/header.tsx
@@ -41,7 +41,7 @@ export const Header: ParentComponent<{
   }
 
   return (
-    <header class="dark:bg-solid-darkbg border-b-2px sticky top-0 z-10 flex items-center gap-x-4 border-slate-200 bg-white p-1 px-2 text-sm dark:border-neutral-800">
+    <header class="dark:bg-solid-darkbg border-b-2px z-12 sticky top-0 flex items-center gap-x-4 border-slate-200 bg-white p-1 px-2 text-sm dark:border-neutral-800">
       <A href="/">
         <img src={logo} alt="solid-js logo" class="w-8" />
       </A>

--- a/packages/solid-repl/src/components/preview.tsx
+++ b/packages/solid-repl/src/components/preview.tsx
@@ -269,22 +269,24 @@ export const Preview: Component<Props> = (props) => {
   });
   return (
     <div class="flex min-h-0 flex-1 flex-col" ref={outerContainer} classList={props.classList}>
-      <iframe
-        title="Solid REPL"
-        class="dark:bg-other block min-h-0 min-w-0 overflow-scroll bg-white p-0"
-        style={styleScale() + `flex: ${props.devtools ? iframeHeight() : 1};`}
-        ref={iframe}
-        src={iframeSrcUrl()}
-        onload={() => {
-          isIframeReady = true;
+      <div class="min-h-0 min-w-0" style={`flex: ${props.devtools ? iframeHeight() : 1};`}>
+        <iframe
+          title="Solid REPL"
+          class="dark:bg-other block h-full w-full overflow-scroll bg-white p-0"
+          style={styleScale()}
+          ref={iframe}
+          src={iframeSrcUrl()}
+          onload={() => {
+            isIframeReady = true;
 
-          if (devtoolsLoaded) iframe.contentWindow!.postMessage({ event: 'LOADED' }, '*');
-          if (props.code) iframe.contentWindow!.postMessage({ event: 'CODE_UPDATE', value: props.code }, '*');
-          iframe.contentDocument!.documentElement.classList.toggle('dark', props.isDark);
-        }}
-        // @ts-ignore
-        sandbox="allow-popups-to-escape-sandbox allow-scripts allow-popups allow-forms allow-pointer-lock allow-top-navigation allow-modals allow-same-origin"
-      />
+            if (devtoolsLoaded) iframe.contentWindow!.postMessage({ event: 'LOADED' }, '*');
+            if (props.code) iframe.contentWindow!.postMessage({ event: 'CODE_UPDATE', value: props.code }, '*');
+            iframe.contentDocument!.documentElement.classList.toggle('dark', props.isDark);
+          }}
+          // @ts-ignore
+          sandbox="allow-popups-to-escape-sandbox allow-scripts allow-popups allow-forms allow-pointer-lock allow-top-navigation allow-modals allow-same-origin"
+        />
+      </div>
       <Show when={props.devtools}>
         <GridResizer
           ref={resizer}
@@ -294,15 +296,17 @@ export const Preview: Component<Props> = (props) => {
           }}
         />
       </Show>
-      <iframe
-        title="Devtools"
-        class="min-h-0 min-w-0"
-        style={`flex: ${1 - iframeHeight()};`}
-        ref={devtoolsIframe}
-        src={devtoolsSrc}
-        onload={() => (devtoolsLoaded = true)}
-        classList={{ block: props.devtools, hidden: !props.devtools }}
-      />
+      <div class="min-h-0 min-w-0" style={`flex: ${1 - iframeHeight()};`}>
+        <iframe
+          title="Devtools"
+          class="h-full w-full"
+          style={styleScale()}
+          ref={devtoolsIframe}
+          src={devtoolsSrc}
+          onload={() => (devtoolsLoaded = true)}
+          classList={{ block: props.devtools, hidden: !props.devtools }}
+        />
+      </div>
     </div>
   );
 };

--- a/packages/solid-repl/src/components/preview.tsx
+++ b/packages/solid-repl/src/components/preview.tsx
@@ -2,6 +2,23 @@ import { Component, Show, createEffect, createMemo, createSignal, onCleanup, unt
 import { useZoom } from '../hooks/useZoom';
 import { GridResizer } from './gridResizer';
 
+const dispatchKeyboardEventToParentZoomState = () => `
+  document.addEventListener('keydown', (e) => {
+    if (!(e.ctrlKey || e.metaKey)) return;
+    if(!['=', '-'].includes(e.key)) return
+
+    const options = {
+      key: e.key,
+      ctrlKey: e.ctrlKey,
+      metaKey: e.metaKey
+    }
+    const keyboardEvent = new KeyboardEvent('keydown', options)
+    window.parent.document.dispatchEvent(keyboardEvent)
+
+    e.preventDefault()
+  });
+`;
+
 const generateHTML = (isDark: boolean, importMap: string) => `
   <!doctype html>
   <html${isDark ? ' class="dark"' : ''}>
@@ -144,6 +161,8 @@ const generateHTML = (isDark: boolean, importMap: string) => `
             console.error(e);
           }
         });
+
+        ${dispatchKeyboardEventToParentZoomState()}
       </script>
     </head>
     <body>
@@ -168,6 +187,9 @@ const useDevtoolsSrc = () => {
       }
     }
   </style>
+  <script>
+    ${dispatchKeyboardEventToParentZoomState()}
+  </script>
   <meta name="referrer" content="no-referrer">
   <script src="https://unpkg.com/@ungap/custom-elements/es.js"></script>
   <script type="module" src="https://cdn.jsdelivr.net/npm/chii@1.8.0/public/front_end/entrypoints/chii_app/chii_app.js"></script>


### PR DESCRIPTION
Fixes editor scrollbars overlapping popups.
<img width="436" alt="Screenshot 2024-03-24 at 7 11 55 PM" src="https://github.com/solidjs/solid-playground/assets/29286430/ba6441d1-4e39-437a-bf31-10761ede01d7">
<img width="423" alt="Screenshot 2024-03-24 at 7 12 20 PM" src="https://github.com/solidjs/solid-playground/assets/29286430/8f3276d5-30fd-4350-b6d9-e5bc1a21b166">

Fixes broken preview iframe that hides grid resizer and iframe devtools, after zooming in. Ryan encountered [this issue on one his streams](https://www.youtube.com/live/sMbICJUGJj4?feature=shared&t=1961).
<img width="657" alt="Screenshot 2024-03-24 at 7 15 20 PM" src="https://github.com/solidjs/solid-playground/assets/29286430/efb13ade-ca0f-4bdb-9b1e-0e50b076543d">

Now it's fixed and you can zoom in/out as much as you like.
<img width="849" alt="Screenshot 2024-03-24 at 7 18 09 PM" src="https://github.com/solidjs/solid-playground/assets/29286430/0e767847-6bae-44ac-91f7-ae76b5960451">

Also fixes issue when focused inside iframes, when zooming in ( while `Override browser zoom keyboard shortcut` is `true` ), it defaults to browser page zoom. Now the iframes prevents this default behavior and dispatches the keyboard press to parent context and triggers custom zoom.