### PR TITLE
Remove firefox warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,6 @@ $ pnpm run dev
 $ pnpm run build
 ```
 
-:warning: Firefox doesn't work by default in development (`pnpm dev`) due to to [vite's limitation with web worker](https://vitejs.dev/guide/features.html#web-workers). However it still works after build (`pnpm build`)
-
-To develop on Firefox, ensure that `dom.workers.modules.enabled` is enabled in `about:config`
-
 ## Credits / Technologies used
 
 - [solid-js](https://github.com/solidjs/solid/): The view library


### PR DESCRIPTION
Firefox does support worker modules by default, if the browser has been updated in the past 9 months.

https://caniuse.com/?search=module%20worker