### PR TITLE
Bump solid-repl to 0.26.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "1.0.0",
   "description": "",
   "scripts": {
+    "start": "cd packages/playground && pnpm start",
     "build": "cd packages/playground && pnpm build",
     "dev": "cd packages/playground && pnpm dev",
     "format": "prettier -w ."

--- a/packages/solid-repl/package.json
+++ b/packages/solid-repl/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.25.0",
+  "version": "0.26.0",
   "name": "solid-repl",
   "description": "Quickly discover what the solid compiler will generate from your JSX template",
   "repository": {


### PR DESCRIPTION
If this is published, we can move forward with updating i.e. the Tutorial, so it has an up-to-date output, same as the playground.

Awaiting
- #170 
- #171 