### PR TITLE
Fix preview iframe height when devtools disabled and other issues

### DIFF
--- a/packages/playground/src/components/zoomDropdown.tsx
+++ b/packages/playground/src/components/zoomDropdown.tsx
@@ -87,7 +87,7 @@ export const ZoomDropdown: Component<{ showMenu: boolean }> = (props) => {
     >
       <button
         type="button"
-        class="flex flex-row items-center space-x-2 rounded px-2 py-2 opacity-80 hover:opacity-100 md:px-1"
+        class="flex w-full flex-row items-center space-x-2 rounded px-2 py-2 opacity-80 hover:opacity-100 md:px-1"
         classList={{
           'rounded-none active:bg-gray-300 hover:bg-gray-300 dark:hover:text-black': props.showMenu,
           'bg-gray-300 dark:text-black': open() && props.showMenu,

--- a/packages/playground/src/index.tsx
+++ b/packages/playground/src/index.tsx
@@ -1,8 +1,8 @@
 import { render } from 'solid-js/web';
 import { App } from './app';
 import { registerServiceWorker } from './utils/serviceWorker';
-import 'virtual:uno.css';
 import 'solid-repl/repl/main.css';
+import 'virtual:uno.css';
 
 render(() => <App />, document.querySelector('#app')!);
 

--- a/packages/solid-repl/package.json
+++ b/packages/solid-repl/package.json
@@ -45,6 +45,7 @@
   },
   "dependencies": {
     "@solid-primitives/media": "^2.2.8",
+    "@solid-primitives/platform": "^0.1.2",
     "@solid-primitives/scheduled": "^1.4.3",
     "dedent": "^1.5.1",
     "monaco-editor-textmate": "^4.0.0",

--- a/packages/solid-repl/src/components/gridResizer.tsx
+++ b/packages/solid-repl/src/components/gridResizer.tsx
@@ -48,11 +48,17 @@ export const GridResizer: Component<{
 
   createEffect(() => {
     if (isDragging()) {
+      // Fixes Firefox issue where dragging cursor fails to emit events to overlay, and instead to iframe, resulting in resizer bar not moving.
+      // use class instead of style because style attribute, when tracked, value is reset. Related to https://github.com/solidjs/solid/issues/1938
+      document.querySelectorAll('iframe').forEach((el) => el.classList.add('pointer-events-none'));
+
       window.addEventListener('mousemove', onMouseMove);
       window.addEventListener('mouseup', onResizeEnd);
       window.addEventListener('touchmove', onTouchMove);
       window.addEventListener('touchend', onResizeEnd);
     } else {
+      document.querySelectorAll('iframe').forEach((el) => el.classList.remove('pointer-events-none'));
+
       window.removeEventListener('mousemove', onMouseMove);
       window.removeEventListener('mouseup', onResizeEnd);
       window.removeEventListener('touchmove', onTouchMove);

--- a/packages/solid-repl/src/components/gridResizer.tsx
+++ b/packages/solid-repl/src/components/gridResizer.tsx
@@ -1,5 +1,6 @@
 import { Component, createSignal, createEffect, onCleanup } from 'solid-js';
 import { throttle } from '@solid-primitives/scheduled';
+import { isFirefox } from '@solid-primitives/platform';
 
 const Dot: Component<{ isDragging: boolean }> = (props) => {
   return (
@@ -49,14 +50,18 @@ export const GridResizer: Component<{
   createEffect(() => {
     if (isDragging()) {
       // Fixes Firefox issue where dragging cursor fails to emit events to overlay, and instead to iframe, resulting in resizer bar not moving.
-      document.querySelectorAll('iframe').forEach((el) => (el.style.pointerEvents = 'none'));
+      if (isFirefox) {
+        document.querySelectorAll('iframe').forEach((el) => (el.style.pointerEvents = 'none'));
+      }
 
       window.addEventListener('mousemove', onMouseMove);
       window.addEventListener('mouseup', onResizeEnd);
       window.addEventListener('touchmove', onTouchMove);
       window.addEventListener('touchend', onResizeEnd);
     } else {
-      document.querySelectorAll('iframe').forEach((el) => (el.style.pointerEvents = ''));
+      if (isFirefox) {
+        document.querySelectorAll('iframe').forEach((el) => (el.style.pointerEvents = ''));
+      }
 
       window.removeEventListener('mousemove', onMouseMove);
       window.removeEventListener('mouseup', onResizeEnd);

--- a/packages/solid-repl/src/components/gridResizer.tsx
+++ b/packages/solid-repl/src/components/gridResizer.tsx
@@ -49,15 +49,14 @@ export const GridResizer: Component<{
   createEffect(() => {
     if (isDragging()) {
       // Fixes Firefox issue where dragging cursor fails to emit events to overlay, and instead to iframe, resulting in resizer bar not moving.
-      // use class instead of style because style attribute, when tracked, value is reset. Related to https://github.com/solidjs/solid/issues/1938
-      document.querySelectorAll('iframe').forEach((el) => el.classList.add('pointer-events-none'));
+      document.querySelectorAll('iframe').forEach((el) => (el.style.pointerEvents = 'none'));
 
       window.addEventListener('mousemove', onMouseMove);
       window.addEventListener('mouseup', onResizeEnd);
       window.addEventListener('touchmove', onTouchMove);
       window.addEventListener('touchend', onResizeEnd);
     } else {
-      document.querySelectorAll('iframe').forEach((el) => el.classList.remove('pointer-events-none'));
+      document.querySelectorAll('iframe').forEach((el) => (el.style.pointerEvents = ''));
 
       window.removeEventListener('mousemove', onMouseMove);
       window.removeEventListener('mouseup', onResizeEnd);

--- a/packages/solid-repl/src/components/preview.tsx
+++ b/packages/solid-repl/src/components/preview.tsx
@@ -1,4 +1,4 @@
-import { Component, Show, createEffect, createMemo, createSignal, onCleanup, untrack } from 'solid-js';
+import { Component, JSX, Show, createEffect, createMemo, createSignal, onCleanup, untrack } from 'solid-js';
 import { useZoom } from '../hooks/useZoom';
 import { GridResizer } from './gridResizer';
 
@@ -262,12 +262,21 @@ export const Preview: Component<Props> = (props) => {
   window.addEventListener('message', messageListener);
   onCleanup(() => window.removeEventListener('message', messageListener));
 
-  const styleScale = () => {
-    if (zoomState.scale === 100 || !zoomState.scaleIframe) return '';
+  const styleScale = (): JSX.CSSProperties => {
+    if (zoomState.scale === 100 || !zoomState.scaleIframe) return {};
 
-    return `width: ${zoomState.scale}%; height: ${zoomState.scale}%; transform: scale(${
-      zoomState.zoom / 100
-    }); transform-origin: 0 0;`;
+    const sizePercentage = `${zoomState.scale}%`;
+    const width = sizePercentage;
+    const height = sizePercentage;
+    const transform = `scale(${zoomState.zoom / 100})`;
+    const transformOrigin = `0 0`;
+
+    return {
+      width,
+      height,
+      transform,
+      'transform-origin': transformOrigin,
+    };
   };
 
   const [iframeHeight, setIframeHeight] = createSignal<number>(0.625);

--- a/packages/solid-repl/src/components/preview.tsx
+++ b/packages/solid-repl/src/components/preview.tsx
@@ -5,17 +5,17 @@ import { GridResizer } from './gridResizer';
 const dispatchKeyboardEventToParentZoomState = () => `
   document.addEventListener('keydown', (e) => {
     if (!(e.ctrlKey || e.metaKey)) return;
-    if(!['=', '-'].includes(e.key)) return
+    if (!['=', '-'].includes(e.key)) return;
 
     const options = {
       key: e.key,
       ctrlKey: e.ctrlKey,
-      metaKey: e.metaKey
-    }
-    const keyboardEvent = new KeyboardEvent('keydown', options)
-    window.parent.document.dispatchEvent(keyboardEvent)
+      metaKey: e.metaKey,
+    };
+    const keyboardEvent = new KeyboardEvent('keydown', options);
+    window.parent.document.dispatchEvent(keyboardEvent);
 
-    e.preventDefault()
+    e.preventDefault();
   });
 `;
 

--- a/packages/solid-repl/src/components/preview.tsx
+++ b/packages/solid-repl/src/components/preview.tsx
@@ -291,7 +291,7 @@ export const Preview: Component<Props> = (props) => {
   });
   return (
     <div class="flex min-h-0 flex-1 flex-col" ref={outerContainer} classList={props.classList}>
-      <div class="min-h-0 min-w-0" style={`flex: ${props.devtools ? iframeHeight() : 1};`}>
+      <div class="min-h-0 min-w-0" style={`flex: ${props.devtools ? iframeHeight() : '1 1 100%'};`}>
         <iframe
           title="Solid REPL"
           class="dark:bg-other block h-full w-full overflow-scroll bg-white p-0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       '@solid-primitives/media':
         specifier: ^2.2.8
         version: 2.2.8(solid-js@1.8.16)
+      '@solid-primitives/platform':
+        specifier: ^0.1.2
+        version: 0.1.2(solid-js@1.8.16)
       '@solid-primitives/scheduled':
         specifier: ^1.4.3
         version: 1.4.3(solid-js@1.8.16)
@@ -1204,6 +1207,14 @@ packages:
       '@solid-primitives/rootless': 1.4.5(solid-js@1.8.16)
       '@solid-primitives/static-store': 0.0.8(solid-js@1.8.16)
       '@solid-primitives/utils': 6.2.3(solid-js@1.8.16)
+      solid-js: 1.8.16
+    dev: false
+
+  /@solid-primitives/platform@0.1.2(solid-js@1.8.16):
+    resolution: {integrity: sha512-sSxcZfuUrtxcwV0vdjmGnZQcflACzMfLriVeIIWXKp8hzaS3Or3tO6EFQkTd3L8T5dTq+kTtLvPscXIpL0Wzdg==}
+    peerDependencies:
+      solid-js: ^1.6.12
+    dependencies:
       solid-js: 1.8.16
     dev: false
 


### PR DESCRIPTION
When devtools is disabled, the preview iframe height doesn't fully extend to preview panel height.
<img width="200" alt="Screenshot 2024-03-25 at 6 00 25 PM" src="https://github.com/solidjs/solid-playground/assets/29286430/0b256563-c0d1-4dc5-80da-44db41e7d529">
The result after fixing the height.
<img width="200" alt="Screenshot 2024-03-25 at 6 01 27 PM" src="https://github.com/solidjs/solid-playground/assets/29286430/4fc79f7f-5b76-4a5d-9a12-79fda59a39f5">

On Firefox, while dragging the gridResizer element, if the cursor moves outside of the gridResizer element, then it fails to drag.
 
https://github.com/solidjs/solid-playground/assets/29286430/74db0919-2d26-41dd-ae13-06bd6a5be4ea

It's expected that events from iframes doesn't bubble to main page, which is why on initial drag, an overlay invisible element is added to overlap elements such as the iframes. For some reason, in Firefox, until the pointer/mouse is released, the overlay is ignored.

One of the solutions is to disable pointer interactions of the iframes by setting their style to `pointer-events: none;`, which [this PR uses](https://github.com/solidjs/solid-playground/blob/8c26a7277ee7cbb91b7dae5c029825057547738e/packages/solid-repl/src/components/gridResizer.tsx#L52-L55). Something to note, the iframe that I'm setting the `style.pointerEvents`, happens to be also set by the [`styleScale`](https://github.com/solidjs/solid-playground/blob/master/packages/solid-repl/src/components/preview.tsx#L265-L271) function that uses zoomState store. Originally this function would return a string, but between store/signal updates, if the iframe element style is edited, it would be lost, causing iframe to be intractable again and gridResizer element to not move. This is why [`styleScale` is changed to return CSS object instead of string](https://github.com/aquaductape/solid-playground/blob/9a7a2cc83d9a0f74e7a7b5efed3e407f8dd6c048/packages/solid-repl/src/components/preview.tsx#L265-L280). Not sure why that fixes it, possibly related to this [issue](https://github.com/solidjs/solid/issues/1938).

Lastly, I changed `solid-repl/repl/main.css` to be imported before `virtual:uno.css`. `solid-repl/repl/main.css` contains a css reset of `@unocss/reset/tailwind.css`, and since it was imported after unocss, caused visual issues such as this button where its background class `bg-gray-300` is overridden by the reset.
<img width="183" alt="Screenshot 2024-03-25 at 10 07 04 PM" src="https://github.com/solidjs/solid-playground/assets/29286430/52d8b7b0-b15b-43bb-932b-a9a505adb018">
<img width="489" alt="Screenshot 2024-03-25 at 10 11 19 PM" src="https://github.com/solidjs/solid-playground/assets/29286430/2bdfd36b-eeae-4a0b-bc04-053fcd3b9bf9">



