### PR TITLE
Fix zooming out and firefox iframe height issues

### DIFF
--- a/packages/solid-repl/src/components/preview.tsx
+++ b/packages/solid-repl/src/components/preview.tsx
@@ -16,7 +16,7 @@ const dispatchKeyboardEventToParentZoomState = () => `
     window.parent.document.dispatchEvent(keyboardEvent);
 
     e.preventDefault();
-  });
+  }, true);
 `;
 
 const generateHTML = (isDark: boolean, importMap: string) => `

--- a/packages/solid-repl/src/components/preview.tsx
+++ b/packages/solid-repl/src/components/preview.tsx
@@ -300,7 +300,7 @@ export const Preview: Component<Props> = (props) => {
   });
   return (
     <div class="flex min-h-0 flex-1 flex-col" ref={outerContainer} classList={props.classList}>
-      <div class="min-h-0 min-w-0" style={`flex: ${props.devtools ? iframeHeight() : '1 1 100%'};`}>
+      <div class="contain-layout min-h-0 min-w-0" style={`flex: ${props.devtools ? iframeHeight() : '1 1 100%'};`}>
         <iframe
           title="Solid REPL"
           class="dark:bg-other block h-full w-full overflow-scroll bg-white p-0"
@@ -327,7 +327,7 @@ export const Preview: Component<Props> = (props) => {
           }}
         />
       </Show>
-      <div class="min-h-0 min-w-0" style={`flex: ${1 - iframeHeight()};`}>
+      <div class="contain-layout min-h-0 min-w-0" style={`flex: ${1 - iframeHeight()};`}>
         <iframe
           title="Devtools"
           class="h-full w-full"

--- a/packages/solid-repl/src/components/preview.tsx
+++ b/packages/solid-repl/src/components/preview.tsx
@@ -300,10 +300,10 @@ export const Preview: Component<Props> = (props) => {
   });
   return (
     <div class="flex min-h-0 flex-1 flex-col" ref={outerContainer} classList={props.classList}>
-      <div class="contain-layout min-h-0 min-w-0" style={`flex: ${props.devtools ? iframeHeight() : '1 1 100%'};`}>
+      <div class="relative" style={`flex: ${props.devtools ? iframeHeight() : '1 1 100%'};`}>
         <iframe
           title="Solid REPL"
-          class="dark:bg-other block h-full w-full overflow-scroll bg-white p-0"
+          class="dark:bg-other absolute inset-0 block h-full w-full overflow-scroll bg-white p-0"
           style={styleScale()}
           ref={iframe}
           src={iframeSrcUrl()}
@@ -327,10 +327,10 @@ export const Preview: Component<Props> = (props) => {
           }}
         />
       </Show>
-      <div class="contain-layout min-h-0 min-w-0" style={`flex: ${1 - iframeHeight()};`}>
+      <div class="relative" style={`flex: ${1 - iframeHeight()};`}>
         <iframe
           title="Devtools"
-          class="h-full w-full"
+          class="absolute inset-0 block h-full w-full"
           style={styleScale()}
           ref={devtoolsIframe}
           src={devtoolsSrc}

--- a/packages/solid-repl/unocss.config.ts
+++ b/packages/solid-repl/unocss.config.ts
@@ -33,18 +33,4 @@ export default defineConfig({
   },
   presets: [presetWind()],
   transformers: [transformerDirectives()],
-  rules: [
-    [
-      /^contain-(.+)$/,
-      ([, name]) => {
-        if (name.includes('|')) return;
-        return {
-          contain: name,
-        };
-      },
-    ],
-  ],
-  autocomplete: {
-    templates: ['contain-(none|strict|content|size|inline-size|layout|style|paint)'],
-  },
 });

--- a/packages/solid-repl/unocss.config.ts
+++ b/packages/solid-repl/unocss.config.ts
@@ -33,4 +33,18 @@ export default defineConfig({
   },
   presets: [presetWind()],
   transformers: [transformerDirectives()],
+  rules: [
+    [
+      /^contain-(.+)$/,
+      ([, name]) => {
+        if (name.includes('|')) return;
+        return {
+          contain: name,
+        };
+      },
+    ],
+  ],
+  autocomplete: {
+    templates: ['contain-(none|strict|content|size|inline-size|layout|style|paint)'],
+  },
 });


### PR DESCRIPTION
In Firefox, when you zoom out (not the browser page zoom) and the zoom percentage is less than 100%, the iframes have an extended "phantom" height, which overflows the main page and making it scrollable. Must a be a Firefox bug, because upon inspection, the iframe as well as their parent containers have no overflowing height.
<img width="200" alt="Screenshot 2024-03-28 at 2 47 20 AM" src="https://github.com/solidjs/solid-playground/assets/29286430/7d4b6e1a-7895-4bd5-938f-9ebfe61e1ee1">
Tried `overflow: hidden`, which does fix main page overflowing, but causes iframes to translate upwards a little bit on the y axis and get clipped. The solution is CSS `contain` which enables isolating that element from the rest of document tree by limiting specific calculations, which in our case is `contain: layout`.

When focused in devtools iframe, then zooming out on mac device <kbd>⌘</kbd> + <kbd>-</kbd>, the keydown listeners preventing default behavior is ignored and browser zooms out page. This is due to `chii` library having a keydown listener that uses event capturing and stops its event propagating. The fix is simply changing our keydown listeners to use event capturing.

