### PR TITLE
Switch back to `esm.sh` from `jspm.dev`

### DIFF
--- a/packages/solid-repl/repl/compiler.ts
+++ b/packages/solid-repl/repl/compiler.ts
@@ -86,7 +86,7 @@ function transformImportee(fileName: string) {
     }
     if (fileName.includes('://')) return fileName;
     else {
-      dataToReturn[fileName] = `https://jspm.dev/${fileName}`;
+      dataToReturn[fileName] = `https://esm.sh/${fileName}`;
       return fileName;
     }
   }

--- a/packages/solid-repl/src/components/repl.tsx
+++ b/packages/solid-repl/src/components/repl.tsx
@@ -123,6 +123,10 @@ export const Repl: ReplProps = (props) => {
     if (event === 'ROLLUP') {
       const currentMap = { ...importMap() };
       for (const file in currentMap) {
+        // Catch any `jspm.dev` URLs and migrate them to `esm.sh`
+        if (currentMap[file] === `https://jspm.dev/${file}`) {
+          currentMap[file] = `https://esm.sh/${file}`;
+        }
         if (!(file in compiled) && currentMap[file] === `https://esm.sh/${file}`) {
           delete currentMap[file];
         }

--- a/packages/solid-repl/src/components/repl.tsx
+++ b/packages/solid-repl/src/components/repl.tsx
@@ -123,7 +123,7 @@ export const Repl: ReplProps = (props) => {
     if (event === 'ROLLUP') {
       const currentMap = { ...importMap() };
       for (const file in currentMap) {
-        if (!(file in compiled) && currentMap[file] === `https://jspm.dev/${file}`) {
+        if (!(file in compiled) && currentMap[file] === `https://esm.sh/${file}`) {
           delete currentMap[file];
         }
       }


### PR DESCRIPTION
`jspm.dev` is being [deprecated](https://jspm.org/jspm-dev-deprecation), and they're no longer building newer module versions - meaning that Solid is stuck at 1.8.7.

This PR switches the CDN back to `esm.sh` and means that the latest versions of packages are available again in the playground without the use of an import map

Closes #163 