### PR TITLE
fix mismatched dependency issues

### DIFF
--- a/packages/solid-repl/src/components/repl.tsx
+++ b/packages/solid-repl/src/components/repl.tsx
@@ -130,6 +130,9 @@ export const Repl: ReplProps = (props) => {
         if (!(file in compiled) && currentMap[file] === `https://esm.sh/${file}`) {
           delete currentMap[file];
         }
+        if (file.split('/')[0] !== 'solid-js' && currentMap[file] === `https://esm.sh/${file}`) {
+          currentMap[file] = `https://esm.sh/${file}?external=solid-js`;
+        }
       }
       for (const file in compiled) {
         if (!(file in currentMap) && !file.startsWith('./')) {


### PR DESCRIPTION
By using [`?external`](https://github.com/esm-dev/esm.sh/blob/324fc67d75c318c1164a6cf5cb4a774e06837d8f/README.md?plain=1#L224), this PR should solve most of the mismatched dependency issues caused by esm.sh's static build.